### PR TITLE
Chg: made overriding DEFAULT_USERNAME easier

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -5,7 +5,7 @@
 
 
 # change this to your own username
-DEFAULT_USERNAME='sindresorhus'
+[[ -z "$DEFAULT_USERNAME" ]] && DEFAULT_USERNAME='sindresorhus'
 
 # threshold (sec) for showing cmd exec time
 CMD_MAX_EXEC_TIME=5


### PR DESCRIPTION
Editing pure.zsh file should not be mandatory to override this variable.
