### PR TITLE
Rename Arch package

### DIFF
--- a/arch/PKGBUILD
+++ b/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Author: Sindre Sorhus
 # Maintainer: Pat Brisbin <pbrisbin@gmail.com>
-pkgname=pure
+pkgname=pure-zsh-prompt
 pkgver=0.0.1
 pkgrel=1
 pkgdesc='pure prompt for zsh'


### PR DESCRIPTION
I just noticed there is already a package in the AUR by the name "pure" 
(for the functional programming language). So I changed it to 
pure-zsh-prompt.
