### PR TITLE
adjusting prompt character, more logical

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -72,7 +72,8 @@ prompt_pure_setup() {
 	[[ "$SSH_CONNECTION" != '' ]] && prompt_pure_username='%n@%m '
 
 	# prompt turns red if the previous command didn't exit with 0
-	PROMPT='%(?.%F{magenta}.%F{red})❯%f '
+	PROMPT='%(?.%F{magenta}.%F{red}❯%F{magenta})❯%f '
+	 
 }
 
 prompt_pure_setup "$@"


### PR DESCRIPTION
prompt character still turns red if the last command didn't exit with 0, but adds another magenta ❯ to show that it was the previous command that failed. IMHO its a better visual feedback than colour alone. try it out ;)
