### PR TITLE
fix mangled prompts

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -64,7 +64,7 @@ prompt_pure_precmd() {
 		command git rev-parse --is-inside-work-tree &>/dev/null &&
 		# check check if there is anything to pull
 		command git fetch &>/dev/null &&
-        # check if there is an upstream configured for this branch
+		# check if there is an upstream configured for this branch
 		command git rev-parse --abbrev-ref @'{u}' &>/dev/null &&
 		(( $(command git rev-list --count HEAD...@'{u}' 2>/dev/null) > 0 )) &&
 		# some crazy ansi magic to inject the symbol into the previous line


### PR DESCRIPTION
this pull requests fixes a few issues I had with pull request #18:
1. error message printed when no configured upstream branch
2. 256 color code used in precmd doesn't work on my terminal
3. preexec hook mangles output when the command itself contains escape
   sequences
4. cursor position isn't restored correctly when you have already began
   typing something before the async command executes
