### PR TITLE
Don't show pull indicator when ahead of remote

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -66,7 +66,7 @@ prompt_pure_precmd() {
 		command git fetch &>/dev/null &&
 		# check if there is an upstream configured for this branch
 		command git rev-parse --abbrev-ref @'{u}' &>/dev/null &&
-		(( $(command git rev-list --count HEAD...@'{u}' 2>/dev/null) > 0 )) &&
+		(( $(command git rev-list --right-only --count HEAD...@'{u}' 2>/dev/null) > 0 )) &&
 		# some crazy ansi magic to inject the symbol into the previous line
 		print -Pn "\e7\e[A\e[1G\e[`prompt_pure_string_length $prompt_pure_preprompt`C%F{cyan}⇣%f\e8"
 	} &!


### PR DESCRIPTION
After making local changes, the pull indicator is shown because `git rev-list` counts the number of commits between the range `HEAD..@{u}` in both directions.
Adding `--right-only` tells it to only count commits that `@{u}` has but `HEAD` doesn't.
