### PR TITLE
Conditionalise git pull check

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -59,7 +59,7 @@ prompt_pure_precmd() {
 	print -P $prompt_pure_preprompt
 
 	# check async if there is anything to pull
-	[[ -z $PURE_GIT_PULL || $PURE_GIT_PULL == true ]] && {
+	(( ${PURE_GIT_PULL:-1} )) && {
 		# check if we're in a git repo
 		command git rev-parse --is-inside-work-tree &>/dev/null &&
 		# check check if there is anything to pull

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ The max execution time of a process before its run time is shown when it exits. 
 
 ### `PURE_GIT_PULL`
 
-Set `PURE_GIT_PULL=false` to prevent Pure from checking whether the current Git remote has been updated.
+Set `PURE_GIT_PULL=0` to prevent Pure from checking whether the current Git remote has been updated.
 
 ## Example
 


### PR DESCRIPTION
Whilst a nice feature, firing off a `git fetch` (and so an SSH/http call) after
_every_ shell interaction is a bit heavy for my liking. This adds the ability to
disable it (whilst keeping it enabled by default).
