### PR TITLE
Add "Terminal" to the title for context

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -54,7 +54,7 @@ prompt_pure_preexec() {
 
 	# shows the current dir and executed command in the title when a process is active
 	print -Pn "\e]0;"
-	echo -nE "$PWD:t: $2"
+	echo -nE "$PWD:t: $2  — Terminal"
 	print -Pn "\a"
 }
 
@@ -65,7 +65,7 @@ prompt_pure_string_length() {
 
 prompt_pure_precmd() {
 	# shows the full path in the title
-	print -Pn '\e]0;%~\a'
+	print -Pn '\e]0;%~  — Terminal\a'
 
 	# git info
 	vcs_info


### PR DESCRIPTION
The lack the text "Terminal" in the window title means
- Its not searchable. I use linux and when I search for Vim in kupfer, it activates currently open vim or opens a new vim. Similarly, I want to search for Terminal and open the existing terminal or launch a new one. Since there is no "Terminal" text in the title, it always fails.
- I am using selfspy to record data on my system usage and it will really help if the window's title contains something static so I can identify the app with that title.

Please let me know if you have any other concerns. Thank you!
