### PR TITLE
Include untracked files in dirtiness check

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -36,7 +36,7 @@ prompt_pure_git_dirty() {
 	# check if we're in a git repo
 	command git rev-parse --is-inside-work-tree &>/dev/null || return
 	# check if it's dirty
-	[[ "$PURE_GIT_UNTRACKED_DIRTY" == 1 ]] && local umode="-unormal" || local umode="-uno"
+	[[ "$PURE_GIT_UNTRACKED_DIRTY" == 0 ]] && local umode="-uno" || local umode="-unormal"
 	command test -n "$(git status --porcelain --ignore-submodules ${umode})"
 
 	(($? == 0)) && echo '*'

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ Set `PURE_GIT_PULL=0` to prevent Pure from checking whether the current Git remo
 
 ### `PURE_GIT_UNTRACKED_DIRTY`
 
-Set `PURE_GIT_UNTRACKED_DIRTY=1` to include untracked files in dirtiness check.
+Set `PURE_GIT_UNTRACKED_DIRTY=0` to not include untracked files in dirtiness check.
 
 ## Example
 


### PR DESCRIPTION
Things to consider:
1. should we remove the `# fastest possible way to check if repo is dirty` comment, because it's not _the_ ultimate fastest solution, it's kind of a comparable performance to few others, i guess;
2. on my machine both this and the original solution (i.e. `git diff --quiet --ignore-submodules HEAD &>/dev/null`) still takes quite a bit of time to get me to the prompt when i'm in the WebKit repo (from about 1-2s up to 9-10s). I'm not working on such a big codebases, but if i were i would like to be able to disable the dirtiness check entirely for a particular session, because it really slows you down if you have to use terminal a bit inside the repo. Should we hide the entire dirtiness check under a flag as well, so people could just set it to false when they need to?
#1, #79
