### PR TITLE
Add support for disabling auto title and emacs term

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -65,8 +65,10 @@ prompt_pure_string_length() {
 }
 
 prompt_pure_precmd() {
-	# shows the full path in the title
-	print -Pn '\e]0;%~\a'
+	if [[ "$DISABLE_AUTO_TITLE" != "true" ]] && [[ "$EMACS" != *term* ]]; then
+		# shows the full path in the title
+		print -Pn '\e]0;%~\a'
+	fi
 
 	# git info
 	vcs_info
@@ -106,7 +108,9 @@ prompt_pure_setup() {
 	autoload -Uz vcs_info
 
 	add-zsh-hook precmd prompt_pure_precmd
-	add-zsh-hook preexec prompt_pure_preexec
+	if [[ "$DISABLE_AUTO_TITLE" != "true" ]] && [[ "$EMACS" != *term* ]]; then
+		add-zsh-hook preexec prompt_pure_preexec
+	fi
 
 	zstyle ':vcs_info:*' enable git
 	zstyle ':vcs_info:git*' formats ' %b'


### PR DESCRIPTION
Printing to title inside emacs term causes strange behavior so I added a flag to disable it when inside emacs, also added support for disabling it anywhere using a flag (in case other terms have this issue).
