### PR TITLE
Refactor async logic and allow for async git status.

### DIFF
--- a/arch/PKGBUILD
+++ b/arch/PKGBUILD
@@ -21,4 +21,6 @@ package() {
   cd $srcdir/$pkgname
   install -Dm644 pure.zsh \
     "$pkgdir/usr/share/zsh/functions/Prompts/prompt_pure_setup"
+  install -Dm644 async.zsh \
+    "$pkgdir/usr/share/zsh/functions/async"
 }

--- a/async.plugin.zsh
+++ b/async.plugin.zsh
@@ -1,0 +1,1 @@
+async.zsh

--- a/async.zsh
+++ b/async.zsh
@@ -1,0 +1,215 @@
+#!/usr/bin/env zsh
+
+#
+# zsh-async
+#
+# version: 0.1.0
+# author: Mathias Fredriksson
+# url: https://github.com/mafredri/zsh-async
+#
+
+# Wrapper for jobs executed by the async worker, gives output in parseable format with execution time
+_async_job() {
+	local out
+	# store the job identifier
+	local job=$1
+	# reset the identifier
+	1=""
+	# store start time
+	local start=$EPOCHREALTIME
+
+	# run the command
+	out=$($job $@ 2>&1)
+	local ret=$?
+
+	# Grab mutex lock
+	read -ep >/dev/null
+
+	# return output
+	print -r -N -n -- $job $ret "$out" $(( $EPOCHREALTIME - $start ))$'\0'
+
+	# Unlock mutex
+	print -p "t"
+}
+
+# The background worker manages all tasks and runs them without interfering with other processes
+_async_worker() {
+	local -A storage
+	local unique=0
+
+	# Process option parameters passed to worker
+	while getopts "np:u" opt; do
+		case "$opt" in
+		# Use SIGWINCH since many others seem to cause zsh to freeze, e.g. ALRM, INFO, etc.
+		n) trap 'kill -WINCH $ASYNC_WORKER_PARENT_PID' CHLD;;
+		p) ASYNC_WORKER_PARENT_PID=$OPTARG;;
+		u) unique=1;;
+		esac
+	done
+
+	# Create a mutex for writing to the terminal through coproc
+	coproc cat
+	# Insert token into coproc
+	print -p "t"
+
+	while read -r cmd; do
+		# Separate on spaces into an array
+		cmd=(${=cmd})
+		local job=$cmd[1]
+
+		# Check for non-job commands sent to worker
+		case "$job" in
+		_killjobs)
+			kill ${${(v)jobstates##*:*:}%=*} &>/dev/null
+			continue
+			;;
+		esac
+
+		# If worker should perform unique jobs
+		if ((unique)); then
+			# Check if a previous job is still running, if yes, let it finnish
+			for pid in ${${(v)jobstates##*:*:}%=*}; do
+				if [[ "${storage[$job]}" == "$pid" ]]; then
+					continue 2
+				fi
+			done
+		fi
+
+		# run task in background
+		_async_job $cmd &
+		# store pid because zsh job manager is extremely unflexible (show jobname as non-unique '$job')...
+		storage[$job]=$!
+	done
+}
+
+#
+#  Get results from finnished jobs and pass it to the to callback function. This is the only way to reliably return the
+#  job name, return code, output and execution time and with minimal effort.
+#
+# usage:
+# 	async_process_results <worker_name> <callback_function>
+#
+# callback_function is called with the following parameters:
+# 	$1 = job name, e.g. the function passed to async_job
+# 	$2 = return code
+# 	$3 = resulting output from execution
+# 	$4 = execution time, floating point e.g. 2.05 seconds
+#
+async_process_results() {
+	integer count=0
+	local -a items
+	local IFS=$'\0'
+
+	typeset -A ASYNC_PROCESS_BUFFER
+	# Read output from zpty and parse it if available
+	while zpty -r $1 line; do
+		# Remove unwanted \r from output
+		ASYNC_PROCESS_BUFFER[$1]+=${line//$'\r'$'\n'/$'\n'}
+		# Split buffer on null characters, preserve empty elements
+		items=("${(@)=ASYNC_PROCESS_BUFFER[$1]}")
+		# Remove last element since it's due to the return string separator structure
+		items=("${(@)items[1,${#items}-1]}")
+
+		# Continue until we receive all information
+		(( ${#items} % 4 )) && continue
+
+		# Work through all results
+		while ((${#items} > 0)); do
+			eval '$2 "${(@)=items[1,4]}"'
+			shift 4 items
+			count+=1
+		done
+
+		# Empty the buffer
+		ASYNC_PROCESS_BUFFER[$1]=""
+	done
+
+	# If we processed any results, return success
+	(( $count )) && return 0
+
+	# No results were processed
+	return 1
+}
+
+#
+# Start a new asynchronous job on specified worker, assumes the worker is running.
+#
+# usage:
+# 	async_job <worker_name> <my_function> [<function_params>]
+#
+async_job() {
+	local worker=$1
+	1=""
+	zpty -w $worker $@
+}
+
+#
+# Flush all current jobs running on a worker. This will terminate any and all running processes under the worker, use
+# with caution.
+#
+# usage:
+# 	async_flush_jobs <worker_name>
+#
+async_flush_jobs() {
+	zpty -t $worker &>/dev/null || return
+
+	# Send kill command to worker
+	zpty -w $1 "_killjobs"
+
+	# Clear all output buffers
+	while zpty -r $1 line; do done
+
+	# Clear any partial buffers
+	typeset -A ASYNC_PROCESS_BUFFER
+	ASYNC_PROCESS_BUFFER[$1]=""
+}
+
+#
+# Start a new async worker with optional parameters, a worker can be told to only run unique tasks and to notify a
+# process when tasks are complete.
+#
+# usage:
+# 	async_start_worker <worker_name> [-u] [-n] [-p <pid>]
+#
+# opts:
+# 	-u unique (only unique job names can run)
+# 	-n notify through SIGWINCH signal
+# 	-p pid to notify (defaults to current pid)
+#
+async_start_worker() {
+	local worker=$1
+	1=""
+	zpty -t $worker &>/dev/null || zpty -b $worker _async_worker -p $$ $@ || async_stop_worker $worker
+}
+
+#
+# Stop one or multiple workers that are running, all unfetched and incomplete work will be lost.
+#
+# usage:
+# 	async_stop_worker <worker_name_1> [<worker_name_2>]
+#
+async_stop_worker() {
+	local ret=0
+	for worker in $@; do
+		zpty -d $worker 2>/dev/null || ret=$?
+	done
+
+	return $ret
+}
+
+#
+# Initialize the required modules for zsh-async. To be called before using the zsh-async library.
+#
+# usage:
+# 	async_init
+#
+async_init() {
+	zmodload zsh/zpty
+	zmodload zsh/datetime
+}
+
+async() {
+	async_init
+}
+
+async "$@"

--- a/async.zsh
+++ b/async.zsh
@@ -3,7 +3,7 @@
 #
 # zsh-async
 #
-# version: 0.1.0
+# version: 0.2.0
 # author: Mathias Fredriksson
 # url: https://github.com/mafredri/zsh-async
 #
@@ -143,6 +143,40 @@ async_job() {
 	zpty -w $worker $@
 }
 
+# This function traps notification signals and calls all registered callbacks
+_async_notify_trap() {
+	for k in ${(k)ASYNC_CALLBACKS}; do
+		async_process_results "${k}" "${ASYNC_CALLBACKS[$k]}"
+	done
+}
+
+#
+# Register a callback for completed jobs. As soon as a job is finnished, async_process_results will be called with the
+# specified callback function. This requires that a worker is initialized with the -n (notify) option.
+#
+# usage:
+# 	async_register_callback <worker_name> <callback_function>
+#
+async_register_callback() {
+	typeset -gA ASYNC_CALLBACKS
+
+	ASYNC_CALLBACKS[$1]="${@[2,${#@}]}"
+
+	trap '_async_notify_trap' WINCH
+}
+
+#
+# Unregister the callback for a specific worker.
+#
+# usage:
+# 	async_unregister_callback <worker_name>
+#
+async_unregister_callback() {
+	typeset -gA ASYNC_CALLBACKS
+
+	unset "ASYNC_CALLBACKS[$1]"
+}
+
 #
 # Flush all current jobs running on a worker. This will terminate any and all running processes under the worker, use
 # with caution.
@@ -151,7 +185,7 @@ async_job() {
 # 	async_flush_jobs <worker_name>
 #
 async_flush_jobs() {
-	zpty -t $worker &>/dev/null || return
+	zpty -t $worker &>/dev/null || return 1
 
 	# Send kill command to worker
 	zpty -w $1 "_killjobs"

--- a/async.zsh
+++ b/async.zsh
@@ -14,7 +14,8 @@ _async_job() {
 	local start=$EPOCHREALTIME
 
 	# run the command
-	local out=$($@ 2>&1)
+	local out
+	out=$($@ 2>&1)
 	local ret=$?
 
 	# Grab mutex lock

--- a/async.zsh
+++ b/async.zsh
@@ -64,7 +64,7 @@ _async_worker() {
 		# If worker should perform unique jobs
 		if ((unique)); then
 			# Check if a previous job is still running, if yes, let it finnish
-			for pid in ${${(v)jobstates##*:*:}%=*}; do
+			for pid in ${${(v)jobstates##*:*:}%\=*}; do
 				if [[ "${storage[$job]}" == "$pid" ]]; then
 					continue 2
 				fi

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "postinstall": "dest=/usr/local/share/zsh/site-functions/; mkdir -p $dest && ln -sf \"$PWD/pure.zsh\" $dest/prompt_pure_setup || echo 'Could not automagically symlink the prompt. Check out the readme on how to do it manually: https://github.com/sindresorhus/pure#manually'"
+    "postinstall": "dest=/usr/local/share/zsh/site-functions/; mkdir -p $dest && ln -sf \"$PWD/pure.zsh\" $dest/prompt_pure_setup && ln -sf \"$PWD/async.zsh\" $dest/async || echo 'Could not automagically symlink the prompt. Check out the readme on how to do it manually: https://github.com/sindresorhus/pure#manually'"
   },
   "files": [
     "pure.zsh"

--- a/pure.zsh
+++ b/pure.zsh
@@ -40,7 +40,7 @@ prompt_pure_human_time() {
 
 # fastest possible way to check if repo is dirty
 prompt_pure_git_dirty() {
-	cd $1
+	eval "cd '$@'"
 
 	[[ "$(command git rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]] && {
 		# check if it's dirty
@@ -56,7 +56,7 @@ prompt_pure_git_dirty() {
 }
 
 prompt_pure_git_fetch() {
-	cd $1
+	eval "cd '$@'"
 
 	(( ${PURE_GIT_PULL:-1} )) && {
 		# check if we're in a git repo

--- a/pure.zsh
+++ b/pure.zsh
@@ -205,17 +205,20 @@ prompt_pure_async_callback() {
 	local output=$3
 	local exec_time=$4
 
-	if [[ "$job" == "prompt_pure_async_git_dirty" ]]; then
-		prompt_pure_git_dirty=$output
-		prompt_pure_preprompt_render
+	case "${job}" in
+		prompt_pure_async_git_dirty)
+			prompt_pure_git_dirty=$output
+			prompt_pure_preprompt_render
 
-		# when prompt_pure_git_delay_dirty_check is set, the git info is displayed in a different color, this is why the
-		# prompt is rendered before the variable is (potentially) set
-		(( $exec_time > 2 )) && prompt_pure_git_delay_dirty_check=$EPOCHSECONDS
-	elif [[ "$job" == "prompt_pure_async_git_fetch" ]]; then
-		prompt_pure_git_arrows=$(prompt_pure_check_git_arrows)
-		prompt_pure_preprompt_render
-	fi
+			# when prompt_pure_git_delay_dirty_check is set, the git info is displayed in a different color, this is why the
+			# prompt is rendered before the variable is (potentially) set
+			(( $exec_time > 2 )) && prompt_pure_git_delay_dirty_check=$EPOCHSECONDS
+			;;
+		prompt_pure_async_git_fetch)
+			prompt_pure_git_arrows=$(prompt_pure_check_git_arrows)
+			prompt_pure_preprompt_render
+			;;
+	esac
 }
 
 prompt_pure_setup() {

--- a/pure.zsh
+++ b/pure.zsh
@@ -15,6 +15,12 @@
 # %n => username
 # %m => shortname host
 # %(?..) => prompt conditional - %(condition.true.false)
+# terminal codes:
+# \e7   => save cursor position
+# \e[2A => move cursor 2 lines up
+# \e[1G => go to position 1 in terminal
+# \e8   => restore cursor position
+# \e[K  => clears everything after the cursor on the current line
 
 
 # turns seconds into human readable time
@@ -34,13 +40,106 @@ prompt_pure_human_time() {
 
 # fastest possible way to check if repo is dirty
 prompt_pure_git_dirty() {
-	# check if we're in a git repo
-	[[ "$(command git rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]] || return
-	# check if it's dirty
-	[[ "$PURE_GIT_UNTRACKED_DIRTY" == 0 ]] && local umode="-uno" || local umode="-unormal"
-	command test -n "$(git status --porcelain --ignore-submodules ${umode})"
+	local dirty=""
+	local start=$EPOCHSECONDS
 
-	(($? == 0)) && echo '*'
+	[[ "$(command git rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]] && {
+		# check if it's dirty
+		[[ "$PURE_GIT_UNTRACKED_DIRTY" == 0 ]] && local umode="-uno" || local umode="-unormal"
+		command test -n "$(git status --porcelain --ignore-submodules ${umode})"
+
+		(($? == 0)) && dirty="*"
+	}
+
+	echo "dirty|${dirty}:$(( $EPOCHSECONDS - $start ))"
+}
+
+prompt_pure_git_fetch() {
+	local state=""
+	local start=$EPOCHSECONDS
+
+	(( ${PURE_GIT_PULL:-1} )) && {
+		# check if we're in a git repo
+		[[ "$(command git rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]] &&
+		# make sure working tree is not $HOME
+		[[ "$(command git rev-parse --show-toplevel)" != "$HOME" ]] &&
+		# check check if there is anything to pull
+		command git fetch &>/dev/null &&
+		state="done"
+	}
+
+	echo "fetch|${state}:$(( $EPOCHSECONDS - $start ))"
+}
+
+prompt_pure_git_arrows() {
+	# check if there is an upstream configured for this branch
+	command git rev-parse --abbrev-ref @'{u}' &>/dev/null && {
+		local arrows=''
+		(( $(command git rev-list --right-only --count HEAD...@'{u}' 2>/dev/null) > 0 )) && arrows='⇣'
+		(( $(command git rev-list --left-only --count HEAD...@'{u}' 2>/dev/null) > 0 )) && arrows+='⇡'
+		# output the arrows
+		echo " %F{cyan}${arrows}%f"
+	}
+}
+
+prompt_pure_check_worker_results() {
+	integer count=0
+
+	# read output from zpty and parse it if available
+	while zpty -r prompt_pure_worker line; do
+		count+=1
+		local cmd=${line%|*}
+		local result=${line#*|}
+		local value=${result%:*}
+		local timestamp=${result#*:}
+		# remove ^M at end
+		timestamp=${timestamp//[^0-9]/}
+
+		[[ $cmd == "dirty" ]] && {
+			_prompt_git_dirty=$value
+			(( ${timestamp} > 2 )) && _prompt_git_delay_dirty_check=$EPOCHSECONDS
+		}
+		[[ $cmd == "fetch" && $value == "done" ]] && _prompt_git_arrows=$(prompt_pure_git_arrows)
+	done
+
+	# if there were results, attempt to redraw the preprompt
+	(( $count )) && prompt_pure_preprompt_render
+
+	# re-start time for periodic instance
+	[[ $1 == "periodic" ]] && sched +15 prompt_pure_check_worker_results periodic
+
+	# because this task can run at any time, prevent it from destroying last cmd return status
+	return ${_prompt_ret}
+}
+
+# the background worker does some processing for us without locking up the terminal
+prompt_pure_background_worker() {
+	local storage
+	typeset -A storage
+
+	while read -r line; do
+		local cmd=${line%|*}
+		local dir=${line#*|}
+		local job="prompt_pure_git_${cmd}"
+
+		# change working directory if it has changed
+		[[ ${storage[dir]} != $dir ]] && {
+			cd "$dir"
+			# kill any child processes still running, we don't care about their results
+			kill ${${(v)jobstates##*:*:}%=*} &>/dev/null
+			storage[dir]=$dir
+		}
+
+		# check if a previous job is still running, if yes, let it finnish
+		for pid in ${${(v)jobstates##*:*:}%=*}; do
+			[[ "${storage[$cmd]}" == "$pid" ]] && continue 2
+		done
+
+		# run task in background
+		$job &
+		# store pid because zsh job manager is extremely unflexible (show jobname as non-unique '$job')...
+		storage[$cmd]=$!
+	done
 }
 
 # displays the exec time of the last command if set threshold was exceeded
@@ -66,37 +165,80 @@ prompt_pure_string_length() {
 	echo $(( ${#${(S%%)1//(\%([KF1]|)\{*\}|\%[Bbkf])}} - 1 ))
 }
 
+prompt_pure_preprompt_render() {
+	# check that no command is currently running, rendering might not be safe
+	[[ -n ${cmd_timestamp+x} ]] && return
+
+	# get vcs info
+	vcs_info
+
+	local prompt="%F{blue}%~%F{242}${vcs_info_msg_0_}${_prompt_git_dirty}$prompt_pure_username%f%F{yellow}${_prompt_exec_time}%f${_prompt_git_arrows}"
+	local prompt_length=$(prompt_pure_string_length $prompt)
+	local lines=$(( $prompt_length / $COLUMNS + 1 ))
+
+	# if executing through precmd, do not perform fancy terminal editing
+	if [[ "$1" == "precmd" ]]; then
+		print -P "\n${prompt}"
+	else
+		# only redraw if prompt has changed
+		[[ "${_prompt_previous_prompt}" != "${prompt}" ]] || return
+
+		# disable clearing of line if last char of prompt is last column of terminal
+		local clr="\e[K"
+		(( $prompt_length * $lines == $COLUMNS - 1 )) && clr=""
+
+		# modify previous prompt
+		# {
+		print -Pn "\e7\e[${lines}A\e[1G${prompt}${clr}\e8" #} &!
+	fi
+
+	# store previous prompt for comparison
+	_prompt_previous_prompt=$prompt
+}
+
 prompt_pure_precmd() {
+	_prompt_ret=$?
 	# shows the full path in the title
 	print -Pn '\e]0;%~\a'
 
-	# git info
-	vcs_info
-
-	local prompt_pure_preprompt="\n%F{blue}%~%F{242}$vcs_info_msg_0_`prompt_pure_git_dirty`$prompt_pure_username%f%F{yellow}`prompt_pure_cmd_exec_time`%f"
-	print -P $prompt_pure_preprompt
-
-	# check async if there is anything to pull
-	(( ${PURE_GIT_PULL:-1} )) && {
-		# check if we're in a git repo
-		[[ "$(command git rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]] &&
-		# make sure working tree is not $HOME
-		[[ "$(command git rev-parse --show-toplevel)" != "$HOME" ]] &&
-		# check check if there is anything to pull
-		command git fetch &>/dev/null &&
-		# check if there is an upstream configured for this branch
-		command git rev-parse --abbrev-ref @'{u}' &>/dev/null && {
-			local arrows=''
-			(( $(command git rev-list --right-only --count HEAD...@'{u}' 2>/dev/null) > 0 )) && arrows='⇣'
-			(( $(command git rev-list --left-only --count HEAD...@'{u}' 2>/dev/null) > 0 )) && arrows+='⇡'
-			print -Pn "\e7\e[A\e[1G\e[`prompt_pure_string_length $prompt_pure_preprompt`C%F{cyan}${arrows}%f\e8"
-		}
-	} &!
-
-	# reset value since `preexec` isn't always triggered
+	# store exec time for when preprompt gets re-rendered
+	_prompt_exec_time=$(prompt_pure_cmd_exec_time)
 	unset cmd_timestamp
+
+	# make sure the worker is initialized, delete it if it has failed
+	zpty -t prompt_pure_worker &>/dev/null || zpty -b prompt_pure_worker prompt_pure_background_worker || zpty -d prompt_pure_worker
+
+	# check for possible worker results now, and in a second
+	prompt_pure_check_worker_results
+	sched +1 prompt_pure_check_worker_results
+
+	# if dirty checking is sufficiently fast, tell worker to check it again, or wait for timeout
+	(( $EPOCHSECONDS - ${_prompt_git_delay_dirty_check:-0} > ${PURE_GIT_DELAY_DIRTY_CHECK:-1800} )) &&
+	zpty -w prompt_pure_worker "dirty|$PWD"
+
+	# tell worker to do a git fetch
+	zpty -w prompt_pure_worker "fetch|$PWD"
+
+	# print the preprompt
+	prompt_pure_preprompt_render precmd
+
+	return ${_prompt_ret}
 }
 
+prompt_pure_chpwd() {
+	# prefix working_tree with x as to not match current path, affects variable resolution
+	local working_tree="x$(command git rev-parse --show-toplevel 2>/dev/null)"
+
+	# check if the working tree has changed and run git fetch immediately
+	if [ "${_pure_git_working_tree}" != "${working_tree}" ]; then
+		# reset git preprompt variables, switching working tree
+		_prompt_git_dirty=
+		_prompt_git_delay_dirty_check=
+		_prompt_git_arrows=$(prompt_pure_git_arrows)
+
+		_pure_git_working_tree=$working_tree
+	fi
+}
 
 prompt_pure_setup() {
 	# prevent percentage showing up
@@ -108,12 +250,17 @@ prompt_pure_setup() {
 
 	prompt_opts=(cr subst percent)
 
+	# loat zpty and sched for async & monitoring
+	zmodload zsh/zpty
+	zmodload zsh/sched
+
 	zmodload zsh/datetime
 	autoload -Uz add-zsh-hook
 	autoload -Uz vcs_info
 
 	add-zsh-hook precmd prompt_pure_precmd
 	add-zsh-hook preexec prompt_pure_preexec
+	add-zsh-hook chpwd prompt_pure_chpwd
 
 	zstyle ':vcs_info:*' enable git
 	zstyle ':vcs_info:git*' formats ' %b'
@@ -127,6 +274,11 @@ prompt_pure_setup() {
 
 	# prompt turns red if the previous command didn't exit with 0
 	PROMPT="%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f "
+
+	# trigger initial chpwd for new sessions
+	prompt_pure_chpwd
+	# initialize periodic check for worker results
+	sched +15 prompt_pure_check_worker_results periodic
 }
 
 prompt_pure_setup "$@"

--- a/pure.zsh
+++ b/pure.zsh
@@ -40,7 +40,7 @@ prompt_pure_human_time() {
 
 # fastest possible way to check if repo is dirty
 prompt_pure_git_dirty() {
-	eval "cd '$@'"
+	cd "$*"
 
 	[[ "$(command git rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]] && {
 		# check if it's dirty
@@ -56,7 +56,7 @@ prompt_pure_git_dirty() {
 }
 
 prompt_pure_git_fetch() {
-	eval "cd '$@'"
+	cd "$*"
 
 	(( ${PURE_GIT_PULL:-1} )) && {
 		# check if we're in a git repo

--- a/pure.zsh
+++ b/pure.zsh
@@ -133,8 +133,7 @@ prompt_pure_preprompt_render() {
 		(( $prompt_length * $lines == $COLUMNS - 1 )) && clr=""
 
 		# modify previous prompt
-		# {
-		print -Pn "\e7\e[${lines}A\e[1G${prompt}${clr}\e8" #} &!
+		print -Pn "\e7\e[${lines}A\e[1G${prompt}${clr}\e8"
 	fi
 
 	# store previous prompt for comparison

--- a/pure.zsh
+++ b/pure.zsh
@@ -40,23 +40,19 @@ prompt_pure_human_time() {
 
 # fastest possible way to check if repo is dirty
 prompt_pure_git_dirty() {
-	local dirty=""
-	local start=$EPOCHSECONDS
+	cd $1
 
 	[[ "$(command git rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]] && {
 		# check if it's dirty
 		[[ "$PURE_GIT_UNTRACKED_DIRTY" == 0 ]] && local umode="-uno" || local umode="-unormal"
 		command test -n "$(git status --porcelain --ignore-submodules ${umode})"
 
-		(($? == 0)) && dirty="*"
+		(($? == 0)) && echo "*"
 	}
-
-	echo "dirty|${dirty}:$(( $EPOCHSECONDS - $start ))"
 }
 
 prompt_pure_git_fetch() {
-	local state=""
-	local start=$EPOCHSECONDS
+	cd $1
 
 	(( ${PURE_GIT_PULL:-1} )) && {
 		# check if we're in a git repo
@@ -64,11 +60,8 @@ prompt_pure_git_fetch() {
 		# make sure working tree is not $HOME
 		[[ "$(command git rev-parse --show-toplevel)" != "$HOME" ]] &&
 		# check check if there is anything to pull
-		command git fetch &>/dev/null &&
-		state="done"
+		command git fetch &>/dev/null
 	}
-
-	echo "fetch|${state}:$(( $EPOCHSECONDS - $start ))"
 }
 
 prompt_pure_git_arrows() {
@@ -80,66 +73,6 @@ prompt_pure_git_arrows() {
 		# output the arrows
 		echo " %F{cyan}${arrows}%f"
 	}
-}
-
-prompt_pure_check_worker_results() {
-	integer count=0
-
-	# read output from zpty and parse it if available
-	while zpty -r prompt_pure_worker line; do
-		count+=1
-		local cmd=${line%|*}
-		local result=${line#*|}
-		local value=${result%:*}
-		local timestamp=${result#*:}
-		# remove ^M at end
-		timestamp=${timestamp//[^0-9]/}
-
-		[[ $cmd == "dirty" ]] && {
-			_prompt_git_dirty=$value
-			(( ${timestamp} > 2 )) && _prompt_git_delay_dirty_check=$EPOCHSECONDS
-		}
-		[[ $cmd == "fetch" && $value == "done" ]] && _prompt_git_arrows=$(prompt_pure_git_arrows)
-	done
-
-	# if there were results, attempt to redraw the preprompt
-	(( $count )) && prompt_pure_preprompt_render
-
-	# re-start time for periodic instance
-	[[ $1 == "periodic" ]] && sched +15 prompt_pure_check_worker_results periodic
-
-	# because this task can run at any time, prevent it from destroying last cmd return status
-	return ${_prompt_ret}
-}
-
-# the background worker does some processing for us without locking up the terminal
-prompt_pure_background_worker() {
-	local storage
-	typeset -A storage
-
-	while read -r line; do
-		local cmd=${line%|*}
-		local dir=${line#*|}
-		local job="prompt_pure_git_${cmd}"
-
-		# change working directory if it has changed
-		[[ ${storage[dir]} != $dir ]] && {
-			cd "$dir"
-			# kill any child processes still running, we don't care about their results
-			kill ${${(v)jobstates##*:*:}%=*} &>/dev/null
-			storage[dir]=$dir
-		}
-
-		# check if a previous job is still running, if yes, let it finnish
-		for pid in ${${(v)jobstates##*:*:}%=*}; do
-			[[ "${storage[$cmd]}" == "$pid" ]] && continue 2
-		done
-
-		# run task in background
-		$job &
-		# store pid because zsh job manager is extremely unflexible (show jobname as non-unique '$job')...
-		storage[$cmd]=$!
-	done
 }
 
 # displays the exec time of the last command if set threshold was exceeded
@@ -169,9 +102,6 @@ prompt_pure_preprompt_render() {
 	# check that no command is currently running, rendering might not be safe
 	[[ -n ${cmd_timestamp+x} && "$1" != "precmd" ]] && return
 
-	# get vcs info
-	vcs_info
-
 	local prompt="%F{blue}%~%F{242}${vcs_info_msg_0_}${_prompt_git_dirty}$prompt_pure_username%f%F{yellow}${_prompt_exec_time}%f${_prompt_git_arrows}"
 	local prompt_length=$(prompt_pure_string_length $prompt)
 	local lines=$(( $prompt_length / $COLUMNS + 1 ))
@@ -199,31 +129,23 @@ prompt_pure_preprompt_render() {
 prompt_pure_precmd() {
 	_prompt_ret=$?
 
-	# set timestamp, indicates preprompt locking from child processes
+	# store exec time for when preprompt gets re-rendered
+	_prompt_exec_time=$(prompt_pure_cmd_exec_time)
+
+	# set timestamp, indicates that preprompt should not be redrawn even if a redraw is triggered
 	cmd_timestamp=${cmd_timestamp:-$EPOCHSECONDS}
 
 	# shows the full path in the title
 	print -Pn '\e]0;%~\a'
 
-	# make sure the worker is initialized, delete it if it has failed
-	zpty -t prompt_pure_worker &>/dev/null || zpty -b prompt_pure_worker prompt_pure_background_worker || zpty -d prompt_pure_worker
+	# preform async git dirty check and fetch
+	prompt_pure_async_tasks
 
-	# check for possible worker results now, and in a second
-	prompt_pure_check_worker_results
-	sched +1 prompt_pure_check_worker_results
-
-	# if dirty checking is sufficiently fast, tell worker to check it again, or wait for timeout
-	(( $EPOCHSECONDS - ${_prompt_git_delay_dirty_check:-0} > ${PURE_GIT_DELAY_DIRTY_CHECK:-1800} )) &&
-	zpty -w prompt_pure_worker "dirty|$PWD"
-
-	# tell worker to do a git fetch
-	zpty -w prompt_pure_worker "fetch|$PWD"
-
-	# store exec time for when preprompt gets re-rendered
-	_prompt_exec_time=$(prompt_pure_cmd_exec_time)
+	# get vcs info
+	vcs_info
 
 	# print the preprompt
-	prompt_pure_preprompt_render precmd
+	prompt_pure_preprompt_render "precmd"
 
 	unset cmd_timestamp
 
@@ -236,6 +158,9 @@ prompt_pure_chpwd() {
 
 	# check if the working tree has changed and run git fetch immediately
 	if [ "${_pure_git_working_tree}" != "${working_tree}" ]; then
+		# stop any running async jobs
+		async_flush_jobs "prompt_pure"
+
 		# reset git preprompt variables, switching working tree
 		_prompt_git_dirty=
 		_prompt_git_delay_dirty_check=
@@ -243,6 +168,41 @@ prompt_pure_chpwd() {
 
 		_pure_git_working_tree=$working_tree
 	fi
+}
+
+prompt_pure_async_tasks() {
+	# initialize async worker
+	((!${_pure_async_init:-0})) && {
+		trap '
+			async_process_results "prompt_pure" prompt_pure_async_callback
+		' WINCH
+		async_start_worker "prompt_pure" -u -n
+		_pure_async_init=1
+	}
+
+	# tell worker to do a git fetch
+	async_job "prompt_pure" prompt_pure_git_fetch $PWD
+
+	# if dirty checking is sufficiently fast, tell worker to check it again, or wait for timeout
+	local dirty_check=$(( $EPOCHSECONDS - ${_prompt_git_delay_dirty_check:-0} ))
+	if (( $dirty_check > ${PURE_GIT_DELAY_DIRTY_CHECK:-1800} )); then
+		async_job "prompt_pure" prompt_pure_git_dirty $PWD
+	fi
+}
+
+prompt_pure_async_callback() {
+	local job=$1
+	local output=$3
+	local exec_time=$4
+
+	if [[ "$job" == "prompt_pure_git_dirty" ]]; then
+		_prompt_git_dirty=$output
+		(( $exec_time > 2 )) && _prompt_git_delay_dirty_check=$EPOCHSECONDS
+	elif [[ "$job" == "prompt_pure_git_fetch" ]]; then
+		_prompt_git_arrows=$(prompt_pure_git_arrows)
+	fi
+
+	prompt_pure_preprompt_render
 }
 
 prompt_pure_setup() {
@@ -255,13 +215,10 @@ prompt_pure_setup() {
 
 	prompt_opts=(cr subst percent)
 
-	# loat zpty and sched for async & monitoring
-	zmodload zsh/zpty
-	zmodload zsh/sched
-
 	zmodload zsh/datetime
 	autoload -Uz add-zsh-hook
 	autoload -Uz vcs_info
+	autoload -Uz async && async
 
 	add-zsh-hook precmd prompt_pure_precmd
 	add-zsh-hook preexec prompt_pure_preexec
@@ -282,8 +239,6 @@ prompt_pure_setup() {
 
 	# trigger initial chpwd for new sessions
 	prompt_pure_chpwd
-	# initialize periodic check for worker results
-	sched +15 prompt_pure_check_worker_results periodic
 }
 
 prompt_pure_setup "$@"

--- a/pure.zsh
+++ b/pure.zsh
@@ -118,8 +118,9 @@ prompt_pure_precmd() {
 	# store exec time for when preprompt gets re-rendered
 	prompt_pure_cmd_exec_time=$(prompt_pure_check_cmd_exec_time)
 
-	# set timestamp, indicates that preprompt should not be redrawn even if a redraw is triggered
-	prompt_pure_cmd_timestamp=${prompt_pure_cmd_timestamp:-$EPOCHSECONDS}
+	# by making sure that prompt_pure_cmd_timestamp is defined here the async functions are prevented from interfering
+	# with the initial preprompt rendering
+	prompt_pure_cmd_timestamp=
 
 	# check for git arrows
 	prompt_pure_git_arrows=$(prompt_pure_check_git_arrows)
@@ -136,6 +137,7 @@ prompt_pure_precmd() {
 	# print the preprompt
 	prompt_pure_preprompt_render "precmd"
 
+	# remove the prompt_pure_cmd_timestamp, indicating that precmd has completed
 	unset prompt_pure_cmd_timestamp
 }
 

--- a/pure.zsh
+++ b/pure.zsh
@@ -115,8 +115,6 @@ prompt_pure_preprompt_render() {
 }
 
 prompt_pure_precmd() {
-	prompt_pure_return_code=$?
-
 	# store exec time for when preprompt gets re-rendered
 	prompt_pure_cmd_exec_time=$(prompt_pure_check_cmd_exec_time)
 
@@ -139,8 +137,6 @@ prompt_pure_precmd() {
 	prompt_pure_preprompt_render "precmd"
 
 	unset prompt_pure_cmd_timestamp
-
-	return $prompt_pure_return_code
 }
 
 # fastest possible way to check if repo is dirty
@@ -218,8 +214,6 @@ prompt_pure_async_callback() {
 		prompt_pure_git_arrows=$(prompt_pure_check_git_arrows)
 		prompt_pure_preprompt_render
 	fi
-
-	return $prompt_pure_return_code
 }
 
 prompt_pure_setup() {

--- a/pure.zsh
+++ b/pure.zsh
@@ -48,6 +48,10 @@ prompt_pure_git_dirty() {
 		command test -n "$(git status --porcelain --ignore-submodules ${umode})"
 
 		(($? == 0)) && echo "*"
+
+		# add artificial delay in such a case that the task is completed "too" fast
+		# otherwise preprompt redraw might interfere with initial draw from precmd
+		sleep 0.01
 	}
 }
 

--- a/pure.zsh
+++ b/pure.zsh
@@ -75,7 +75,7 @@ prompt_pure_git_arrows() {
 		(( $(command git rev-list --right-only --count HEAD...@'{u}' 2>/dev/null) > 0 )) && arrows='⇣'
 		(( $(command git rev-list --left-only --count HEAD...@'{u}' 2>/dev/null) > 0 )) && arrows+='⇡'
 		# output the arrows
-		echo " ${arrows}"
+		[[ "$arrows" != "" ]] && echo " ${arrows}"
 	}
 }
 

--- a/pure.zsh
+++ b/pure.zsh
@@ -189,10 +189,8 @@ prompt_pure_chpwd() {
 prompt_pure_async_tasks() {
 	# initialize async worker
 	((!${_pure_async_init:-0})) && {
-		trap '
-			async_process_results "prompt_pure" prompt_pure_async_callback
-		' WINCH
 		async_start_worker "prompt_pure" -u -n
+		async_register_callback "prompt_pure" prompt_pure_async_callback
 		_pure_async_init=1
 	}
 

--- a/pure.zsh
+++ b/pure.zsh
@@ -145,15 +145,17 @@ prompt_pure_precmd() {
 
 # fastest possible way to check if repo is dirty
 prompt_pure_async_git_dirty() {
-	cd "$*"
+	local untracked_dirty=$2
+	local umode="-unormal"
+	[[ "$untracked_dirty" == "0" ]] && umode="-uno"
 
-	[[ "$PURE_GIT_UNTRACKED_DIRTY" == 0 ]] && local umode="-uno" || local umode="-unormal"
+	cd "$1"
 	command test -n "$(git status --porcelain --ignore-submodules ${umode})"
 	(($? == 0)) && echo "*"
 }
 
 prompt_pure_async_git_fetch() {
-	cd "$*"
+	cd "$1"
 
 	command git fetch
 }
@@ -196,7 +198,7 @@ prompt_pure_async_tasks() {
 		# make sure working tree is not $HOME
 		[[ "${working_tree}" != "$HOME" ]] &&
 		# check check if there is anything to pull
-		async_job "prompt_pure" prompt_pure_async_git_dirty $working_tree
+		async_job "prompt_pure" prompt_pure_async_git_dirty $working_tree $PURE_GIT_UNTRACKED_DIRTY
 	fi
 }
 

--- a/pure.zsh
+++ b/pure.zsh
@@ -132,6 +132,9 @@ prompt_pure_precmd() {
 	# store exec time for when preprompt gets re-rendered
 	_prompt_exec_time=$(prompt_pure_cmd_exec_time)
 
+	# check for git arrows
+	_prompt_git_arrows=$(prompt_pure_git_arrows)
+
 	# set timestamp, indicates that preprompt should not be redrawn even if a redraw is triggered
 	cmd_timestamp=${cmd_timestamp:-$EPOCHSECONDS}
 
@@ -164,7 +167,6 @@ prompt_pure_chpwd() {
 		# reset git preprompt variables, switching working tree
 		_prompt_git_dirty=
 		_prompt_git_delay_dirty_check=
-		_prompt_git_arrows=$(prompt_pure_git_arrows)
 
 		_pure_git_working_tree=$working_tree
 	fi

--- a/readme.md
+++ b/readme.md
@@ -43,10 +43,13 @@ That's it. Skip to [Getting started](#getting-started).
 
 2. Symlink `pure.zsh` to somewhere in [`$fpath`](http://www.refining-linux.org/archives/46/ZSH-Gem-12-Autoloading-functions/) with the name `prompt_pure_setup`.
 
+3. Symlink `async.zsh` in `$fpath` with the name `async`.
+
 #### Example
 
 ```sh
 $ ln -s "$PWD/pure.zsh" /usr/local/share/zsh/site-functions/prompt_pure_setup
+$ ln -s "$PWD/async.zsh" /usr/local/share/zsh/site-functions/async
 ```
 *Run `echo $fpath` to see possible locations.*
 
@@ -61,6 +64,7 @@ Then install the theme there:
 
 ```sh
 $ ln -s "$PWD/pure.zsh" "$HOME/.zfunctions/prompt_pure_setup"
+$ ln -s "$PWD/async.zsh" "$HOME/.zfunctions/async"
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,10 @@ Set `PURE_GIT_PULL=0` to prevent Pure from checking whether the current Git remo
 
 Set `PURE_GIT_UNTRACKED_DIRTY=0` to not include untracked files in dirtiness check. Only really useful on extremely huge repos like the WebKit repo.
 
+### `PURE_GIT_DELAY_DIRTY_CHECK`
+
+Time in seconds to delay git dirty checking for large repositories (git status takes > 2 seconds). The check is performed asynchronously, this is to save CPU. Defaults to `1800` seconds.
+
 ### `PURE_PROMPT_SYMBOL`
 
 Defines the prompt symbol. The default value is `❯`.


### PR DESCRIPTION
This pull request replaces my previous PR (https://github.com/sindresorhus/pure/pull/106) and fixes issues https://github.com/sindresorhus/pure/issues/81 and https://github.com/sindresorhus/pure/issues/102. 

Discussions welcome.

- Pure now uses a background worker for git fetch and git status
- Only one git fetch/status can run at a time
- All worker jobs are eliminated on directory change (consider passing
only git working tree?)
- If a git status takes longer than 2 second, rely on cached result
for 30 minutes (1800 seconds)
- Disowned process no longer takes care of rendering the git up/down
arrows. It is done by the parent process
- Entire preprompt can be redrawn to allow for updating git status,
etc. Works well in both smaller and larger terminals.
- Arrows can be drawn immediately if the data is available

Some ideas:
* Extend the periodical check to perform new checks even when no new action has been take on the terminal. So even a background terminal could inform you that there are changes to pull, etc.
* Make git status execution time-limit configurable (instead of hard-coded 2 seconds)
* Now worker checks are performed 1s after execution and periodically every 15 seconds. Maybe check for worker results more often until children have performed results. Could also increase periodic time to e.g. 1min and make it configurable. 