### PR TITLE
Make sure git background fetch doesn't trigger gc

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -83,7 +83,7 @@ prompt_pure_precmd() {
 		# make sure working tree is not $HOME
 		[[ "$(command git rev-parse --show-toplevel)" != "$HOME" ]] &&
 		# check check if there is anything to pull
-		command git fetch &>/dev/null &&
+		command git -c gc.auto=0 fetch &>/dev/null &&
 		# check if there is an upstream configured for this branch
 		command git rev-parse --abbrev-ref @'{u}' &>/dev/null && {
 			local arrows=''


### PR DESCRIPTION
Pass the configuration parameter `gc.auto=0` to `git fetch` so that we don't risk starting a garbage collection when background fetching.