### PR TITLE
Zsh integration compatibility fixes

### DIFF
--- a/arch/PKGBUILD
+++ b/arch/PKGBUILD
@@ -21,6 +21,4 @@ package() {
   cd $srcdir/$pkgname
   install -Dm644 pure.zsh \
     "$pkgdir/usr/share/zsh/functions/Prompts/prompt_pure_setup"
-  install -Dm644 async.zsh \
-    "$pkgdir/usr/share/zsh/functions/async"
 }

--- a/async.plugin.zsh
+++ b/async.plugin.zsh
@@ -1,1 +1,0 @@
-async.zsh

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "postinstall": "dest=/usr/local/share/zsh/site-functions/; mkdir -p $dest && ln -sf \"$PWD/pure.zsh\" $dest/prompt_pure_setup && ln -sf \"$PWD/async.zsh\" $dest/async || echo 'Could not automagically symlink the prompt. Check out the readme on how to do it manually: https://github.com/sindresorhus/pure#manually'"
+    "postinstall": "dest=/usr/local/share/zsh/site-functions/; mkdir -p $dest && ln -sf \"$PWD/pure.zsh\" $dest/prompt_pure_setup || echo 'Could not automagically symlink the prompt. Check out the readme on how to do it manually: https://github.com/sindresorhus/pure#manually'"
   },
   "files": [
     "pure.zsh",

--- a/pure.zsh
+++ b/pure.zsh
@@ -253,4 +253,24 @@ prompt_pure_setup() {
 	PROMPT="%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f "
 }
 
+# http://stackoverflow.com/questions/9901210/bash-source0-equivalent-in-zsh
+# find the real path of pure on-disk, following symlinks
+local pure_source
+local pure_path
+# closest zsh eqvivalent to $BASH_SOURCE
+pure_source="${(%):-%x}"
+# iterate until we find the real file
+while [ -h "$pure_source" ]; do
+	local dir
+	dir="$(cd -P "$(dirname "$pure_source")" && pwd)"
+	pure_source="$(readlink "$pure_source")"
+	[[ $pure_source != /* ]] && pure_source="$dir/$pure_source"
+done
+
+# turn potential relative path into real path
+pure_path="$(cd -P "$(dirname "$pure_source")" && pwd)"
+
+# Soruce async.zsh
+[ -f "$pure_path"/async.zsh ] && . "$pure_path"/async.zsh
+
 prompt_pure_setup "$@"

--- a/pure.zsh
+++ b/pure.zsh
@@ -270,7 +270,7 @@ done
 # turn potential relative path into real path
 pure_path="$(cd -P "$(dirname "$pure_source")" && pwd)"
 
-# Soruce async.zsh
+# source async.zsh
 [ -f "$pure_path"/async.zsh ] && . "$pure_path"/async.zsh
 
 prompt_pure_setup "$@"

--- a/readme.md
+++ b/readme.md
@@ -43,13 +43,10 @@ That's it. Skip to [Getting started](#getting-started).
 
 2. Symlink `pure.zsh` to somewhere in [`$fpath`](http://www.refining-linux.org/archives/46/ZSH-Gem-12-Autoloading-functions/) with the name `prompt_pure_setup`.
 
-3. Symlink `async.zsh` in `$fpath` with the name `async`.
-
 #### Example
 
 ```
 $ ln -s "$PWD/pure.zsh" /usr/local/share/zsh/site-functions/prompt_pure_setup
-$ ln -s "$PWD/async.zsh" /usr/local/share/zsh/site-functions/async
 ```
 *Run `echo $fpath` to see possible locations.*
 
@@ -64,7 +61,6 @@ Then install the theme there:
 
 ```sh
 $ ln -s "$PWD/pure.zsh" "$HOME/.zfunctions/prompt_pure_setup"
-$ ln -s "$PWD/async.zsh" "$HOME/.zfunctions/async"
 ```
 
 


### PR DESCRIPTION
Didn't imagine integrations would break so horribly.

This change should fix problems when integrating with presto an antigen (addresses https://github.com/sindresorhus/pure/issues/118, https://github.com/sindresorhus/pure/issues/120 and https://github.com/sindresorhus/pure/issues/121)

I would appreciate it if everyone with problems (especially issue reporters) could try this branch on their respective zsh-frameworks and see if it fixes the reported problems.

Tested this on prezto already, and seems to work just fine.