### PR TITLE
Show hostname in terminal title if session is over ssh

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -61,9 +61,13 @@ prompt_pure_check_git_arrows() {
 prompt_pure_preexec() {
 	prompt_pure_cmd_timestamp=$EPOCHSECONDS
 
-	# shows the current dir and executed command in the title when a process is active
+	# tell the terminal we are setting the title
 	print -Pn "\e]0;"
-	echo -nE "$PWD:t: $2"
+	# show hostname if connected through ssh
+	[[ "$SSH_CONNECTION" != '' ]] && print -Pn "%m: "
+	# shows the current dir and executed command in the title when a process is active
+	# (use print -r to disable potential evaluation of escape characters in cmd)
+	print -Pnr "$PWD:t: $2"
 	print -Pn "\a"
 }
 
@@ -126,8 +130,12 @@ prompt_pure_precmd() {
 	# check for git arrows
 	prompt_pure_git_arrows=$(prompt_pure_check_git_arrows)
 
+	# tell the terminal we are setting the title
+	print -Pn "\e]0;"
+	# show hostname if connected through ssh
+	[[ "$SSH_CONNECTION" != '' ]] && print -Pn "%m: "
 	# shows the full path in the title
-	print -Pn '\e]0;%~\a'
+	print -Pn "%~\a"
 
 	# get vcs info
 	vcs_info

--- a/pure.zsh
+++ b/pure.zsh
@@ -64,7 +64,7 @@ prompt_pure_preexec() {
 	# tell the terminal we are setting the title
 	print -Pn "\e]0;"
 	# show hostname if connected through ssh
-	[[ "$SSH_CONNECTION" != '' ]] && print -Pn "%m: "
+	[[ "$SSH_CONNECTION" != '' ]] && print -Pn "(%m) "
 	# shows the current dir and executed command in the title when a process is active
 	# (use print -r to disable potential evaluation of escape characters in cmd)
 	print -Pnr "$PWD:t: $2"
@@ -133,7 +133,7 @@ prompt_pure_precmd() {
 	# tell the terminal we are setting the title
 	print -Pn "\e]0;"
 	# show hostname if connected through ssh
-	[[ "$SSH_CONNECTION" != '' ]] && print -Pn "%m: "
+	[[ "$SSH_CONNECTION" != '' ]] && print -Pn "(%m) "
 	# shows the full path in the title
 	print -Pn "%~\a"
 


### PR DESCRIPTION
When logged in through ssh to a machine, say `mafredri@Denver`.
* No command active: `Denver: ~`
* Sleep 10: `Denver: mafredri: sleep 10`