### PR TITLE
Simplifies loading Pure in zgen by adding symbolic link to async

### DIFF
--- a/async.plugin.zsh
+++ b/async.plugin.zsh
@@ -1,0 +1,1 @@
+async.zsh


### PR DESCRIPTION
I use [zgen](https://github.com/tarjoilija/zgen) to load Pure.
Simply doing `zgen load sindresorhus/pure` would not work, and will see the following errors:

```
prompt_pure_setup:10: async: function definition file not found
prompt_pure_async_tasks:3: command not found: async_start_worker
prompt_pure_async_tasks:4: command not found: async_register_callback
```

Adding this symbolic link make it work (without having to do those manual steps in the README).