### PR TITLE
prompt_pure_string_length: no need to subtract one

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -111,7 +111,7 @@ prompt_pure_preprompt_render() {
 
 		# disable clearing of line if last char of preprompt is last column of terminal
 		local clr="\e[K"
-		(( $preprompt_length * $lines == $COLUMNS - 1 )) && clr=""
+		(( $COLUMNS * $lines == $preprompt_length )) && clr=""
 
 		# modify previous preprompt
 		print -Pn "\e7\e[${lines}A\e[1G${preprompt}${clr}\e8"

--- a/pure.zsh
+++ b/pure.zsh
@@ -76,8 +76,7 @@ prompt_pure_preexec() {
 
 # string length ignoring ansi escapes
 prompt_pure_string_length() {
-	# Subtract one since newline is counted as two characters
-	echo $(( ${#${(S%%)1//(\%([KF1]|)\{*\}|\%[Bbkf])}} - 1 ))
+	echo $(( ${#${(S%%)1//(\%([KF1]|)\{*\}|\%[Bbkf])}} ))
 }
 
 prompt_pure_preprompt_render() {
@@ -108,7 +107,7 @@ prompt_pure_preprompt_render() {
 
 		# calculate length of preprompt for redraw purposes
 		local preprompt_length=$(prompt_pure_string_length $preprompt)
-		local lines=$(( $preprompt_length / $COLUMNS + 1 ))
+		local lines=$(( ($preprompt_length - 1) / $COLUMNS + 1 ))
 
 		# disable clearing of line if last char of preprompt is last column of terminal
 		local clr="\e[K"


### PR DESCRIPTION
`prompt_pure_string_length` is used for calculating the length of the preprompt, but the preprompt doesn't contain a newline. This seems to be leading to off-by-one errors in prompt length calculations (which doesn't seem to have dire consequences, though).