### PR TITLE
Preserve preprompt on Ctrl+L

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -47,6 +47,15 @@ prompt_pure_check_cmd_exec_time() {
 	(($elapsed > ${PURE_CMD_MAX_EXEC_TIME:=5})) && prompt_pure_human_time $elapsed
 }
 
+prompt_pure_clear_screen() {
+	# enable output to terminal
+	zle -I
+	# clear screen and move cursor to (0, 0)
+	print -n "\e[2J\e[0;0H"
+	# print preprompt
+	prompt_pure_preprompt_render precmd
+}
+
 prompt_pure_check_git_arrows() {
 	# check if there is an upstream configured for this branch
 	command git rev-parse --abbrev-ref @'{u}' &>/dev/null || return
@@ -249,6 +258,7 @@ prompt_pure_setup() {
 	prompt_opts=(subst percent)
 
 	zmodload zsh/datetime
+	zmodload zsh/zle
 	autoload -Uz add-zsh-hook
 	autoload -Uz vcs_info
 	autoload -Uz async && async
@@ -260,6 +270,13 @@ prompt_pure_setup() {
 	zstyle ':vcs_info:*' use-simple true
 	zstyle ':vcs_info:git*' formats ' %b'
 	zstyle ':vcs_info:git*' actionformats ' %b|%a'
+
+	# if the user has not registered a custom zle widget for clear-screen,
+	# override the builtin one so that the preprompt is displayed correctly when
+	# ^L is issued.
+	if [[ $widgets[clear-screen] == "builtin" ]]; then
+		zle -N clear-screen prompt_pure_clear_screen
+	fi
 
 	# show username@host if logged in through SSH
 	[[ "$SSH_CONNECTION" != '' ]] && prompt_pure_username=' %F{242}%n@%m%f'

--- a/pure.zsh
+++ b/pure.zsh
@@ -51,7 +51,7 @@ prompt_pure_clear_screen() {
 	# enable output to terminal
 	zle -I
 	# clear screen and move cursor to (0, 0)
-	print -n "\e[2J\e[0;0H"
+	print -n '\e[2J\e[0;0H'
 	# print preprompt
 	prompt_pure_preprompt_render precmd
 }
@@ -274,7 +274,7 @@ prompt_pure_setup() {
 	# if the user has not registered a custom zle widget for clear-screen,
 	# override the builtin one so that the preprompt is displayed correctly when
 	# ^L is issued.
-	if [[ $widgets[clear-screen] == "builtin" ]]; then
+	if [[ $widgets[clear-screen] == 'builtin' ]]; then
 		zle -N clear-screen prompt_pure_clear_screen
 	fi
 

--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,12 @@ antigen bundle sindresorhus/pure
 
 ## FAQ
 
+### My preprompt is missing when I clear the screen with Ctrl+L
+
+Pure doesn't register its custom *clear-screen* widget if it has been previously modified. If you haven't registered your own zle widget with `zle -N clear-screen custom-clear-screen` it might have been done by third-party modules. For example `zsh-syntax-highlighting` and `zsh-history-substring-search` are known to do this and they should for that reason be **the very last thing** in your `.zshrc` (as pointed out in their documentation).
+
+To find out the culprit that is overriding your *clear-screen* widget, you can run the following command: `zle -l | grep clear-screen`.
+
 ### I am stuck in a shell loop in my terminal that ask me to authenticate. What should I do ?
 
 [This is a known issue](https://github.com/sindresorhus/pure/issues/76).


### PR DESCRIPTION
As discussed in #145 This PR fixes clear screen in pure (where the preprompt is missing when issuing Ctrl+L).

Due to third-party libraries doing whatever they want, I've decided to take a more fragile, but safer approach in this PR (see https://github.com/sindresorhus/pure/commit/4961520addf1afe298b07cf1f4e32c85fa083ca3 for details).