### PR TITLE
Underline repo name in path display

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -98,7 +98,7 @@ prompt_pure_print_path() {
        if [[ $repo != $upath || $vcs_info_msg_2_ == '.' ]]; then
            local parent="${repo:h}/"
            # if parent is ./ we can safely remove it
-           local _repo="${parent#./}%U${repo:t}%u"
+           local _repo="${parent#./}%B${repo:t}%b%F{blue}"
            upath=${upath/$repo/$_repo}
        fi
    fi

--- a/pure.zsh
+++ b/pure.zsh
@@ -47,55 +47,6 @@ prompt_pure_check_cmd_exec_time() {
 	(($elapsed > ${PURE_CMD_MAX_EXEC_TIME:=5})) && prompt_pure_human_time $elapsed
 }
 
-if [[ "$PURE_HIGHLIGHT_REPO" == 1 ]] ; then
-	# underline
-	PURE_UNDERLINE_START="$(tput smul)"
-	PURE_UNDERLINE_END="$(tput rmul)"
-	# bold
-	# PURE_UNDERLINE_START=${fg_bold[blue]}
-	# PURE_UNDERLINE_END=${fg_no_bold[blue]}
-	prompt_pure_render_preprompt_path() {
-		if [[ -n "$vcs_info_msg_1_" ]] ; then
-			local prerepo reponame postrepo
-			if [[ "$PWD" == "$vcs_info_msg_1_"* ]]; then
-				# the working directory is the real path
-				prerepo=${vcs_info_msg_1_%/*}
-				if [[ "$prerepo" == "$HOME"* ]]; then prerepo="~${prerepo#$HOME}"; fi # replace ~
-				prerepo="${prerepo%/}/"
-				reponame=${vcs_info_msg_1_##*/}
-				postrepo="${PWD#$vcs_info_msg_1_}"
-				postrepo=${postrepo#/}
-				[[ -n "${postrepo}" ]] && postrepo="/${postrepo}"
-				prompt_pure_preprompt_path="%F{blue}${prerepo}${PURE_UNDERLINE_START}${reponame}${PURE_UNDERLINE_END}${postrepo}"
-			elif [[ "$PWD" == */"$vcs_info_msg_2_" ]]; then
-				# the working directory is in a git repository under a symlink
-				local repopath="${PWD%/$vcs_info_msg_2_}"
-				reponame=${repopath##*/}
-				prerepo=${repopath%/*}
-				if [[ "${prerepo}" == "$HOME"* ]]; then prerepo="~${prerepo#$HOME}" fi # replace ~
-				prerepo="${prerepo%/}/"
-				prompt_pure_preprompt_path="%F{blue}${prerepo}${PURE_UNDERLINE_START}${reponame}${PURE_UNDERLINE_END}/$vcs_info_msg_2_"
-			elif [[ "$vcs_info_msg_2_" == "." ]]; then
-				# the working directory is at the root of a repo under a symlink
-				prerepo=${PWD%/*}
-				if [[ "${prerepo}" == "$HOME"* ]]; then prerepo="~${prerepo#$HOME}" fi # replace ~
-				prerepo="${prerepo%/}/"
-				reponame=${PWD##*/}
-				prompt_pure_preprompt_path="%F{blue}${prerepo}${PURE_UNDERLINE_START}${reponame}${PURE_UNDERLINE_END}"
-			else
-				# fallback: the working directory symlinks into a repo somewhere else
-				prompt_pure_preprompt_path="%F{blue}%~"
-			fi
-		else
-			prompt_pure_preprompt_path="%F{blue}%~"
-		fi
-	}
-else
-	prompt_pure_render_preprompt_path() {
-		prompt_pure_preprompt_path="%F{blue}%~"
-	}
-fi
-
 prompt_pure_clear_screen() {
 	# enable output to terminal
 	zle -I
@@ -137,6 +88,24 @@ prompt_pure_string_length() {
 	echo $(( ${#${(S%%)1//(\%([KF1]|)\{*\}|\%[Bbkf])}} ))
 }
 
+prompt_pure_print_path() {
+   local upath='%~'
+   if [[ -n $vcs_info_msg_1_ ]]; then
+       # expand %~
+       upath=${(%)upath}
+       # remove git subdirectory from path to get "pretty" repo path
+       local repo=${upath%'/'$vcs_info_msg_2_}
+       if [[ $repo != $upath || $vcs_info_msg_2_ == '.' ]]; then
+           local parent="${repo:h}/"
+           # if parent is ./ we can safely remove it
+           local _repo="${parent#./}%U${repo:t}%u"
+           upath=${upath/$repo/$_repo}
+       fi
+   fi
+
+   print $upath
+}
+
 prompt_pure_preprompt_render() {
 	# check that no command is currently running, the preprompt will otherwise be rendered in the wrong place
 	[[ -n ${prompt_pure_cmd_timestamp+x} && "$1" != "precmd" ]] && return
@@ -146,9 +115,7 @@ prompt_pure_preprompt_render() {
 	[[ -n ${prompt_pure_git_last_dirty_check_timestamp+x} ]] && git_color=red
 
 	# construct preprompt, beginning with path
-	local prompt_pure_preprompt_path
-	prompt_pure_render_preprompt_path
-	local preprompt="$prompt_pure_preprompt_path"
+	local preprompt="%F{blue}$(prompt_pure_print_path)%f"
 	# git info
 	preprompt+="%F{$git_color}${vcs_info_msg_0_}${prompt_pure_git_dirty}%f"
 	# git pull/push arrows
@@ -320,8 +287,8 @@ prompt_pure_setup() {
 	zstyle ':vcs_info:*' max-exports 3
 	zstyle ':vcs_info:*' enable git
 	zstyle ':vcs_info:*' use-simple true
-	zstyle ':vcs_info:git*' formats ' %b' '%R' '%S'
-	zstyle ':vcs_info:git*' actionformats ' %b|%a' '%R' '%S'
+	zstyle ':vcs_info:git*' formats ' %b' 'x%R' '%S'
+	zstyle ':vcs_info:git*' actionformats ' %b|%a' 'x%R' '%S'
 
 	# if the user has not registered a custom zle widget for clear-screen,
 	# override the builtin one so that the preprompt is displayed correctly when


### PR DESCRIPTION
I'm not sure if this is something that should be put into the repository, it's just an enhancement that I personally like, and have had sitting around for a while (ignore the commit timestamp). This also has a bunch of special casing that definitely would need to be cleaned up before it could be merged, if it's something we should merge at all. And there's probably a better way to perform the string manipulation; I wanted to make sure I didn't fork out to keep it fast, and used the only string manipulation hammer I know (`#` and `%`).

![zsh-pure-underline](https://cloud.githubusercontent.com/assets/760204/8768333/dd09eb06-2e30-11e5-8e99-42f37871c705.png)

obligatory really-big-cuz-that-makes-it-pretty screenshot

![zsh-pure-underline-big-2](https://cloud.githubusercontent.com/assets/760204/8768357/fc537b8e-2e31-11e5-975f-057a3647117f.png)
