### PR TITLE
Deduplicate code by creating a set_title function

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -84,17 +84,26 @@ prompt_pure_check_git_arrows() {
 	[[ -n $arrows ]] && prompt_pure_git_arrows=" ${arrows}"
 }
 
+prompt_pure_set_title() {
+	# tell the terminal we are setting the title
+	print -n '\e]0;'
+	# show hostname if connected through ssh
+	[[ -n $SSH_CONNECTION ]] && print -Pn '(%m) '
+	case $1 in
+		expand-prompt)
+			print -Pn $2;;
+		ignore-escape)
+			print -rn $2;;
+	esac
+	# end set title
+	print -n '\a'
+}
+
 prompt_pure_preexec() {
 	prompt_pure_cmd_timestamp=$EPOCHSECONDS
 
-	# tell the terminal we are setting the title
-	print -Pn "\e]0;"
-	# show hostname if connected through ssh
-	[[ "$SSH_CONNECTION" != '' ]] && print -Pn "(%m) "
-	# shows the current dir and executed command in the title when a process is active
-	# (use print -r to disable potential evaluation of escape characters in cmd)
-	print -nr "$PWD:t: $2"
-	print -Pn "\a"
+	# shows the current dir and executed command in the title while a process is active
+	prompt_pure_set_title 'ignore-escape' "$PWD:t: $2"
 }
 
 # string length ignoring ansi escapes
@@ -190,12 +199,8 @@ prompt_pure_precmd() {
 	# check for git arrows
 	prompt_pure_check_git_arrows
 
-	# tell the terminal we are setting the title
-	print -Pn "\e]0;"
-	# show hostname if connected through ssh
-	[[ "$SSH_CONNECTION" != '' ]] && print -Pn "(%m) "
 	# shows the full path in the title
-	print -Pn "%~\a"
+	prompt_pure_set_title 'expand-prompt' '%~'
 
 	# get vcs info
 	vcs_info


### PR DESCRIPTION
While considering #160 it bothered me a bit that there was duplicated code for setting the title. Lately I've also been thinking about making pure extendable. This PR removes code duplication and allows some form of extendability through hacking around pure.

Example of disabling and restoring title setting functionality:

```zsh
orig_set_title="$(whence -f prompt_pure_set_title)"
pure_restore_set_title() {
	eval "$orig_set_title"
}
pure_disable_set_title() {
	prompt_pure_set_title() {}
}
```

I didn't do this refactor for this effect primarily though, it's just a side-effect.