### PR TITLE
Attempt to detect user initiated git fetch

### DIFF
--- a/async.zsh
+++ b/async.zsh
@@ -81,7 +81,12 @@ _async_worker() {
 		# Check for non-job commands sent to worker
 		case "$job" in
 		_killjobs)
-			kill -KILL ${${(v)jobstates##*:*:}%\=*} &>/dev/null
+			# Do nothing in the worker when receiving the TERM signal
+			trap '' TERM
+			# Send TERM to the entire process group (PID and all children)
+			kill -TERM -$$ &>/dev/null
+			# Reset trap
+			trap - TERM
 			continue
 			;;
 		esac

--- a/pure.zsh
+++ b/pure.zsh
@@ -100,8 +100,8 @@ prompt_pure_set_title() {
 }
 
 prompt_pure_preexec() {
-	# attempt to detect and prevent prompt_pure_async_git_fetch from interfering with the user
-	[[ $2 =~ git\ .*(pull|fetch) ]] && async_flush_jobs 'prompt_pure'
+	# attempt to detect and prevent prompt_pure_async_git_fetch from interfering with user initiated git or hub fetch
+	[[ $2 =~ (git|hub)\ .*(pull|fetch) ]] && async_flush_jobs 'prompt_pure'
 
 	prompt_pure_cmd_timestamp=$EPOCHSECONDS
 

--- a/pure.zsh
+++ b/pure.zsh
@@ -100,6 +100,9 @@ prompt_pure_set_title() {
 }
 
 prompt_pure_preexec() {
+	# attempt to detect and prevent prompt_pure_async_git_fetch from interfering with the user
+	[[ $2 =~ git\ .*(pull|fetch) ]] && async_flush_jobs 'prompt_pure'
+
 	prompt_pure_cmd_timestamp=$EPOCHSECONDS
 
 	# shows the current dir and executed command in the title while a process is active


### PR DESCRIPTION
This PR addresses the issue described in #162.

When a user initiated git fetch is detected, all current async jobs for pure are aborted in an attempt to give way for the user initiated one.

Without this, there is always a chance that pure is running a git fetch at the same time as the user, essentially preventing the user from updating some objects.

**Note:** I've been running for ~10 days now and have not run into the issue.