### PR TITLE
Use append argument of fetch to not clobber FETCH_HEAD

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -239,7 +239,7 @@ prompt_pure_async_git_fetch() {
 	builtin cd -q "$*"
 
 	# set GIT_TERMINAL_PROMPT=0 to disable auth prompting for git fetch (git 2.3+)
-	GIT_TERMINAL_PROMPT=0 command git -c gc.auto=0 fetch
+	GIT_TERMINAL_PROMPT=0 command git -c gc.auto=0 fetch --append
 }
 
 prompt_pure_async_tasks() {


### PR DESCRIPTION
I discovered this issue while I was playing with `git subtree`:

```
» git fetch origin v0.5.1 && git rev-parse FETCH_HEAD
From git://github.com/sindresorhus/pure
 * tag               v0.5.1     -> FETCH_HEAD

320e26b8a29f3a4e203820881bfb20c52bc75ffe

» git rev-parse FETCH_HEAD 
f2ca766346345546fecbdeb2f232b3d34f96fc68
```

And with this patch, the bottom SHA will be the same as the top SHA.

The one downside is that, if the user doesn't manually fetch or pull for a long time, the FETCH_HEAD will get quite large. We could manually trim this.

Also, I used the long version of `--append` instead of the short `-a` since `-a` often means all.

Docs: https://git-scm.com/docs/git-fetch#_options
