### PR TITLE
Add PURE_SET_TITLE option

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -85,7 +85,7 @@ prompt_pure_check_git_arrows() {
 }
 
 prompt_pure_set_title() {
-	# do not set title if PURE_SET_TITLE is equal to 0
+	# do not set title if PURE_SET_TITLE is set to 0
 	(( ${PURE_SET_TITLE:-1} == 0 )) && return
 
 	# tell the terminal we are setting the title

--- a/pure.zsh
+++ b/pure.zsh
@@ -85,6 +85,9 @@ prompt_pure_check_git_arrows() {
 }
 
 prompt_pure_set_title() {
+	# do not set title if PURE_SET_TITLE is equal to 0
+	(( ${PURE_SET_TITLE:-1} == 0 )) && return
+
 	# tell the terminal we are setting the title
 	print -n '\e]0;'
 	# show hostname if connected through ssh

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,10 @@ Defines the git down arrow symbol. The default value is `⇣`.
 
 Defines the git up arrow symbol. The default value is `⇡`.
 
+## `PURE_SET_TITLE`
+
+Set `PURE_SET_TITLE=0` to prevent Pure from setting terminal title.
+
 ## Example
 
 ```sh


### PR DESCRIPTION
I propose to add an option to be able to decide whether Pure should change a terminal title.
In some cases like https://github.com/sindresorhus/pure/issues/188 one may want to be able to disable this feature.

