### PR TITLE
Update and simplify oh-my-zsh integration instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -134,10 +134,8 @@ To have commands colorized as seen in the screenshot install [zsh-syntax-highlig
 
 ### [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
 
-1. Remove competing theme included in oh-my-zsh `~/.oh-my-zsh/themes/pure.zsh-theme`
-2. Symlink (or copy) `pure.zsh` to `~/.oh-my-zsh/custom/pure.zsh-theme`
-3. Symlink (or copy) `async.zsh` to `~/.oh-my-zsh/custom/async.zsh`
-4. Add `ZSH_THEME="pure"` to your `.zshrc` file.
+1. Symlink (or copy) `pure.zsh` to `~/.oh-my-zsh/custom/themes/pure.zsh-theme`.
+2. Set `ZSH_THEME="pure"` in your `.zshrc` file.
 
 ### [prezto](https://github.com/sorin-ionescu/prezto)
 


### PR DESCRIPTION
As per [Oh My Zsh: Overriding and adding themes](https://github.com/robbyrussell/oh-my-zsh/wiki/Customization#overriding-and-adding-themes), the theme should go in the `.oh-my-zsh/custom/themes/` directory. Doing so will allow it to override the included *pure* theme without having to delete it.

Additionally, there is no need to symlink or copy `async.zsh` into `.oh-my-zsh/custom/` since it should already exist in `$fpath` given a proper installation.

Resolves #194 (looks like others have encountered this too)