### PR TITLE
Restore prompt_subst setopt when rendering prompt

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -123,7 +123,10 @@ prompt_pure_string_length_to_var() {
 }
 
 prompt_pure_preprompt_render() {
-	# make sure prompt_subst is unset to prevent parameter expansion in prompt
+	# store the current prompt_subst setting so that it can be restored later
+	local prompt_subst_status=$options[prompt_subst]
+
+	# make sure prompt_subst is unset to prevent parameter expansion in preprompt
 	setopt local_options no_prompt_subst
 
 	# check that no command is currently running, the preprompt will otherwise be rendered in the wrong place
@@ -191,6 +194,11 @@ prompt_pure_preprompt_render() {
 
 		# modify previous preprompt
 		print -Pn "${clr_prev_preprompt}\e[${lines}A\e[${COLUMNS}D${preprompt}${clr}\n"
+
+		if [[ $prompt_subst_status = 'on' ]]; then
+			# re-eanble prompt_subst for expansion on PS1
+			setopt prompt_subst
+		fi
 
 		# redraw prompt (also resets cursor position)
 		zle && zle .reset-prompt
@@ -324,6 +332,8 @@ prompt_pure_setup() {
 
 	zmodload zsh/datetime
 	zmodload zsh/zle
+	zmodload zsh/parameter
+
 	autoload -Uz add-zsh-hook
 	autoload -Uz vcs_info
 	autoload -Uz async && async


### PR DESCRIPTION
We store the user setting for `prompt_subst` before changing it in the local scope of `prompt_pure_preprompt_render`. This allows us to restore it when we render the real prompt (`PS1`) through `zle .redraw-prompt`.

Fixes #230.

---

The was also one other way to fix this, to use anonymous functions in both places where we print the preprompt. Either solution is good imo, anonymous perhaps slightly cleaner (and doesn't depend on `zsh/parameter`) but I decided to go with this approach, mainly for the reason that I don't know when anonymous functions were introduced into zsh.

Example of anonymous version:

```zsh
	if [[ "$1" == "precmd" ]]; then
		() {
			setopt local_options no_prompt_subst
			print -P "\n${preprompt}"
		}
	else
        ...
		# modify previous preprompt
		() {
			setopt local_options no_prompt_subst
			print -Pn "${clr_prev_preprompt}\e[${lines}A\e[${COLUMNS}D${preprompt}${clr}\n"
		}
```