### PR TITLE
preprompt the last parent directory

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -137,7 +137,7 @@ prompt_pure_preprompt_render() {
 	[[ -n ${prompt_pure_git_last_dirty_check_timestamp+x} ]] && git_color=red
 
 	# construct preprompt, beginning with path
-	local preprompt="%F{blue}%~%f"
+	local preprompt="%F{blue}$(basename $PWD)%f"
 	# git info
 	preprompt+="%F{$git_color}${vcs_info_msg_0_}${prompt_pure_git_dirty}%f"
 	# git pull/push arrows


### PR DESCRIPTION
What do you think?

<img width="466" alt="screen shot 2016-12-01 at 22 01 55" src="https://cloud.githubusercontent.com/assets/2096101/20812422/cd33deb4-b811-11e6-9200-7d35f3dd5f88.png">

Instead of 

<img width="466" alt="screen shot 2016-12-01 at 22 02 26" src="https://cloud.githubusercontent.com/assets/2096101/20812433/dbc7f4ec-b811-11e6-9002-edc1a456ce46.png">

moar minimalistic
