### PR TITLE
Add support for custom prompt arrow color

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -364,7 +364,7 @@ prompt_pure_setup() {
 	[[ $UID -eq 0 ]] && prompt_pure_username=' %F{white}%n%f%F{242}@%m%f'
 
 	# prompt turns red if the previous command didn't exit with 0
-	PROMPT="%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f "
+	PROMPT="%(?.%F{${PURE_PROMPT_COLOR_NORMAL:-magenta}}.%F{${PURE_PROMPT_COLOR_FAIL:-red}})${PURE_PROMPT_SYMBOL:-❯}%f "
 }
 
 prompt_pure_setup "$@"

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,14 @@ Defines the git down arrow symbol. The default value is `⇣`.
 
 Defines the git up arrow symbol. The default value is `⇡`.
 
+### `PURE_PROMPT_COLOR_FAIL`
+
+Defines the prompt arrow color when commands fail. The default is `red`.
+
+### `PURE_PROMPT_COLOR_NORMAL`
+
+Defines the prompt arrow color when commands complete successfully. The default is `magenta`.
+
 ## Example
 
 ```sh


### PR DESCRIPTION
### Feature
Support custom prompt arrow color when commands complete or fail.

This can be controlled via the following options:
`PURE_PROMPT_COLOR_NORMAL` and `PURE_PROMPT_COLOR_FAIL`

### Reasoning
- There is not enough contrast in the colors between the default color for successful commands (`magenta`) and the default color for failed commands (`red`). 
- In fact, for color-blind folks, `red` and `magenta` appear as the same color.