### PR TITLE
Readme improvements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ Most prompts are cluttered, ugly and slow. I wanted something visually pleasing 
 
 ## Install
 
-Can be installed with `npm` or manually. Requires git 2.0.0+ and ZSH 5.0.0+.
+Can be installed with `npm` or manually. Requires git 2.0.0+ and zsh 5.2+. Older versions of zsh are known to work, but they are **not** recommended.
 
 ### npm
 

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ Most prompts are cluttered, ugly and slow. I wanted something visually pleasing 
 
 ## Install
 
-Can be installed with `npm` or manually. Requires Git 2.0.0+ and ZSH 5.2+. Older versions of zsh are known to work, but they are **not** recommended.
+Can be installed with `npm` or manually. Requires Git 2.0.0+ and ZSH 5.2+. Older versions of ZSH are known to work, but they are **not** recommended.
 
 ### npm
 

--- a/readme.md
+++ b/readme.md
@@ -137,8 +137,14 @@ To have commands colorized as seen in the screenshot, install [zsh-syntax-highli
 
 ### [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
 
-1. Symlink (or copy) `pure.zsh` to `~/.oh-my-zsh/custom/themes/pure.zsh-theme`.
-2. Set `ZSH_THEME="pure"` in your `.zshrc` file.
+1. Symlink (or copy) `pure.zsh` to `~/.oh-my-zsh/custom/sindresorhus-pure.zsh-theme`.
+2. Symlink (or copy) `async.zsh` to `~/.oh-my-zsh/custom/async.zsh`.
+3. Set `ZSH_THEME="sindresorhus-pure"` in your `.zshrc` file.
+
+Or skip the `oh-my-zsh` integration above and simply:
+
+1. Set `ZSH_THEME=""` in your `.zshrc` to disable oh-my-zsh themes.
+2. Follow the pure [Install](https://github.com/sindresorhus/pure#install) instructions.
 
 ### [prezto](https://github.com/sorin-ionescu/prezto)
 

--- a/readme.md
+++ b/readme.md
@@ -144,7 +144,7 @@ To have commands colorized as seen in the screenshot, install [zsh-syntax-highli
 Or skip the `oh-my-zsh` integration above and simply:
 
 1. Set `ZSH_THEME=""` in your `.zshrc` to disable oh-my-zsh themes.
-2. Follow the pure [Install](https://github.com/sindresorhus/pure#install) instructions.
+2. Follow the Pure [Install](#install) instructions.
 
 ### [prezto](https://github.com/sorin-ionescu/prezto)
 

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ Most prompts are cluttered, ugly and slow. I wanted something visually pleasing 
 
 ## Install
 
-Can be installed with `npm` or manually. Requires git 2.0.0+ and zsh 5.2+. Older versions of zsh are known to work, but they are **not** recommended.
+Can be installed with `npm` or manually. Requires Git 2.0.0+ and ZSH 5.2+. Older versions of zsh are known to work, but they are **not** recommended.
 
 ### npm
 
@@ -137,9 +137,9 @@ To have commands colorized as seen in the screenshot, install [zsh-syntax-highli
 
 ### [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
 
-1. Symlink (or copy) `pure.zsh` to `~/.oh-my-zsh/custom/sindresorhus-pure.zsh-theme`.
+1. Symlink (or copy) `pure.zsh` to `~/.oh-my-zsh/custom/pure.zsh-theme`.
 2. Symlink (or copy) `async.zsh` to `~/.oh-my-zsh/custom/async.zsh`.
-3. Set `ZSH_THEME="sindresorhus-pure"` in your `.zshrc` file.
+3. Set `ZSH_THEME="pure"` in your `.zshrc` file.
 
 Or skip the `oh-my-zsh` integration above and simply:
 


### PR DESCRIPTION
Two changes here:

1. We will now require zsh 5.2+ from this point onwards (reasoning in https://github.com/sindresorhus/pure/commit/d3367ec20bfcbaa230ec8730c38d18a3d3de2bf5)
2. Oh-my-zsh
    * Instructions changed to prevent collision with bundled themes
    * Provide alternate method to avoid integration entirely.

@sindresorhus does this look ok, or can you think of some improvements still?