### PR TITLE
Add zplug install instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -166,11 +166,11 @@ $ antibody bundle sindresorhus/pure
 
 ### [zplug](https://github.com/zplug/zplug)
 
-Update your zshrc with the following lines
+Update your `.zshrc` file with the following lines (order matters):
 
-```shell
-zplug "mafredri/zsh-async", from:github
-zplug "sindresorhus/pure", use:pure.zsh, from:github, as:theme
+```console
+$ zplug mafredri/zsh-async, from:github, defer:0  # Load this first
+$ zplug sindresorhus/pure, use:pure.zsh, from:github, as:theme
 ```
 
 ## FAQ

--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,15 @@ $ antibody bundle mafredri/zsh-async
 $ antibody bundle sindresorhus/pure
 ```
 
+### [zplug](https://github.com/zplug/zplug)
+
+Update your zshrc with the following lines
+
+```shell
+zplug "mafredri/zsh-async", from:github
+zplug "sindresorhus/pure", use:pure.zsh, from:github, as:theme
+```
+
 ## FAQ
 
 ### My preprompt is missing when I clear the screen with Ctrl+L


### PR DESCRIPTION
Adds the install instructions for zplug.

Separates the two for installing zsh-async and pure which #255 does not do