### PR TITLE
Add install instructions for Zim

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,6 +146,12 @@ Pure is bundled with Prezto. No need to install it.
 
 Set `zstyle ':prezto:module:prompt' theme 'pure'` in `~/.zpreztorc`.
 
+### [zim](https://github.com/Eriner/zim)
+
+Pure is bundled with Zim. No need to install it.
+
+Set `zprompt_theme='pure'` in `~/.zimrc`.
+
 ### [antigen](https://github.com/zsh-users/antigen)
 
 Update your `.zshrc` file with the following two lines (order matters). Do not use the `antigen theme` function.


### PR DESCRIPTION
Zim is a newer and optimised version of the prezto Zsh configuration framework. It was almost completely rewritten and is under active development, while prezto is now a dead project.

See also https://github.com/sorin-ionescu/prezto/issues/1239