### PR TITLE
Remove defer:0 from zplug docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -178,10 +178,10 @@ antibody bundle sindresorhus/pure
 
 ### [zplug](https://github.com/zplug/zplug)
 
-Update your `.zshrc` file with the following two lines (order matters):
+Update your `.zshrc` file with the following two lines:
 
 ```sh
-zplug mafredri/zsh-async, from:github, defer:0  # Load this first
+zplug mafredri/zsh-async, from:github
 zplug sindresorhus/pure, use:pure.zsh, from:github, as:theme
 ```
 


### PR DESCRIPTION
@b4b4r07 mentioned [on twitter](https://twitter.com/b4b4r07/status/816519745587453952) that it wasn't necessary.

It seems to be working fine for me even with the lines reversed but I'm unsure how to verify that async is indeed working other than I'm not seeing `command not found` errors like I would if async was completely taken out.