### PR TITLE
Change prezto url to the active prezto repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,7 @@ Or skip the `oh-my-zsh` integration above and simply:
 1. Set `ZSH_THEME=""` in your `.zshrc` to disable oh-my-zsh themes.
 2. Follow the Pure [Install](#install) instructions.
 
-### [prezto](https://github.com/sorin-ionescu/prezto)
+### [prezto](https://github.com/zsh-users/prezto)
 
 Pure is bundled with Prezto. No need to install it.
 


### PR DESCRIPTION
Because @sorin-ionescu has been disappeared for about one year, the previous prezto repo is dead now. New actively maintained repo has been moved to zsh-users. See details on [this issue](https://github.com/sorin-ionescu/prezto/issues/1239).