### PR TITLE
Disable interactive passwords in SSH for git fetch

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -256,7 +256,11 @@ prompt_pure_async_git_fetch() {
 	builtin cd -q "$*"
 
 	# set GIT_TERMINAL_PROMPT=0 to disable auth prompting for git fetch (git 2.3+)
-	GIT_TERMINAL_PROMPT=0 command git -c gc.auto=0 fetch
+	export GIT_TERMINAL_PROMPT=0
+	# set ssh BachMode to disable all interactive ssh password prompting
+	export GIT_SSH_COMMAND=${GIT_SSH_COMMAND:-"ssh -o BatchMode=yes"}
+
+	command git -c gc.auto=0 fetch
 }
 
 prompt_pure_async_tasks() {


### PR DESCRIPTION
This commit fixes a problem where SSH (used by Git) is able to interactively prompt for a password that can not be redirected to `/dev/null`.

An interactive SSH password prompt inside the async worker does three things:
1. Leave the `git fetch` hanging due to waiting for input
2. Capture part of the input to the async worker, thus creating nonsense commands
3. Use some characters from future async jobs as a password and attempts to login

Even if this was fixed in `zsh-async`, it is still good to disable the password prompt to avoid issue numero uno.

I believe there is a chance this could have affected some of our users who have not configured git with an SSH-key.

*Future improvement idea*: Notify the user somehow that they don't have Git set-up properly and can't enjoy the full Pure experience?

**PS.** Allows overriding if need be, before the Pure async worker is initialized (at precmd).