### PR TITLE
Perform all git checks (vcs_info) asynchronously

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -379,7 +379,8 @@ prompt_pure_async_callback() {
 			local -A info
 			typeset -gA prompt_pure_vcs_info
 
-			info=("${(Q@)=output}")
+			# parse output (z) and unquote as array (Q@)
+			info=("${(Q@)${(z)output}}")
 			local -H MATCH
 			# check if git toplevel has changed
 			if [[ $info[top] = $prompt_pure_vcs_info[top] ]]; then

--- a/pure.zsh
+++ b/pure.zsh
@@ -200,7 +200,7 @@ prompt_pure_preprompt_render() {
 		else
 			# When lines equal, we can try to perform a partial prompt update.
 			integer pos
-			for (( pos = 1; pos < $#preprompt_parts; pos++ )); do
+			for (( pos = 1; pos <= $#preprompt_parts; pos++ )); do
 				patch_pos=$pos
 				if [[ $preprompt_parts[$pos] != $prompt_pure_last_preprompt[$pos] ]]; then
 					break  # We found where the preprompts differ.

--- a/pure.zsh
+++ b/pure.zsh
@@ -261,7 +261,7 @@ prompt_pure_async_git_fetch() {
 	# set ssh BachMode to disable all interactive ssh password prompting
 	export GIT_SSH_COMMAND=${GIT_SSH_COMMAND:-"ssh -o BatchMode=yes"}
 
-	command git -c gc.auto=0 fetch &>/dev/null || return 1
+	command git -c gc.auto=0 fetch &>/dev/null || return 99
 
 	# check arrow status after a successful git fetch
 	prompt_pure_async_git_arrows $1
@@ -412,8 +412,10 @@ prompt_pure_async_callback() {
 					prompt_pure_git_arrows=$REPLY
 					prompt_pure_preprompt_render
 				fi
-			else
-				# non-zero exit means there is no upstream configured.
+			elif (( code != 99 )); then
+				# Unless the exit code is 99, prompt_pure_async_git_arrows
+				# failed with a non-zero exit status, meaning there is no
+				# upstream configured.
 				if [[ -n $prompt_pure_git_arrows ]]; then
 					unset prompt_pure_git_arrows
 					prompt_pure_preprompt_render

--- a/pure.zsh
+++ b/pure.zsh
@@ -302,6 +302,16 @@ prompt_pure_async_vcs_info() {
 	setopt localoptions noshwordsplit
 	builtin cd -q $1 2>/dev/null
 
+	# configure vcs_info inside async task, this frees up vcs_info
+	# to be used or configured as the user pleases.
+	zstyle ':vcs_info:*' enable git
+	zstyle ':vcs_info:*' use-simple true
+	# only export two msg variables from vcs_info
+	zstyle ':vcs_info:*' max-exports 2
+	# export branch (%b) and git toplevel (%R)
+	zstyle ':vcs_info:git*' formats '%b' '%R'
+	zstyle ':vcs_info:git*' actionformats '%b|%a' '%R'
+
 	vcs_info
 
 	local -A info
@@ -521,14 +531,6 @@ prompt_pure_setup() {
 
 	add-zsh-hook precmd prompt_pure_precmd
 	add-zsh-hook preexec prompt_pure_preexec
-
-	zstyle ':vcs_info:*' enable git
-	zstyle ':vcs_info:*' use-simple true
-	# only export two msg variables from vcs_info
-	zstyle ':vcs_info:*' max-exports 2
-	# export branch (%b) and git toplevel (%R)
-	zstyle ':vcs_info:git*' formats '%b' '%R'
-	zstyle ':vcs_info:git*' actionformats '%b|%a' '%R'
 
 	# if the user has not registered a custom zle widget for clear-screen,
 	# override the builtin one so that the preprompt is displayed correctly when

--- a/pure.zsh
+++ b/pure.zsh
@@ -59,6 +59,7 @@ prompt_pure_clear_screen() {
 	print -n '\e[2J\e[0;0H'
 	# print preprompt
 	prompt_pure_preprompt_render precmd
+	zle .reset-prompt
 }
 
 prompt_pure_set_title() {

--- a/pure.zsh
+++ b/pure.zsh
@@ -28,7 +28,7 @@
 # 165392 => 1d 21h 56m 32s
 # https://github.com/sindresorhus/pretty-time-zsh
 prompt_pure_human_time_to_var() {
-	local human=" " total_seconds=$1 var=$2
+	local human total_seconds=$1 var=$2
 	local days=$(( total_seconds / 60 / 60 / 24 ))
 	local hours=$(( total_seconds / 60 / 60 % 24 ))
 	local minutes=$(( total_seconds / 60 % 60 ))
@@ -122,22 +122,22 @@ prompt_pure_preprompt_render() {
 	local -a preprompt_parts
 
 	# Set the path.
-	preprompt_parts+=("%F{blue}%~%f")
+	preprompt_parts+=('%F{blue}%~%f')
 
 	# Add git branch and dirty status info.
 	typeset -gA prompt_pure_vcs_info
 	if [[ -n $prompt_pure_vcs_info[branch] ]]; then
-		preprompt_parts+=("%F{$git_color}\${prompt_pure_vcs_info[branch]}\${prompt_pure_git_dirty}%f")
+		preprompt_parts+=('%F{$git_color}${prompt_pure_vcs_info[branch]}${prompt_pure_git_dirty}%f')
 	fi
 	# Git pull/push arrows.
 	if [[ -n $prompt_pure_git_arrows ]]; then
-		preprompt_parts+=("%F{cyan}${prompt_pure_git_arrows}%f")
+		preprompt_parts+=('%F{cyan}${prompt_pure_git_arrows}%f')
 	fi
 
 	# Username and machine, if applicable.
-	[[ -n $prompt_pure_username ]] && preprompt_parts+=($prompt_pure_username)
+	[[ -n $prompt_pure_username ]] && preprompt_parts+=('$prompt_pure_username')
 	# Execution time.
-	[[ -n $prompt_pure_cmd_exec_time ]] && preprompt_parts+=("%F{yellow}${prompt_pure_cmd_exec_time}%f")
+	[[ -n $prompt_pure_cmd_exec_time ]] && preprompt_parts+=('%F{yellow}${prompt_pure_cmd_exec_time}%f')
 
 	local -ah ps1
 
@@ -160,8 +160,6 @@ prompt_pure_preprompt_render() {
 	if [[ $1 != precmd ]] && [[ $prompt_pure_last_prompt != $expanded_prompt ]]; then
 		# Redraw the prompt.
 		zle && zle .reset-prompt
-
-		setopt no_prompt_subst
 	fi
 
 	prompt_pure_last_prompt=$expanded_prompt
@@ -460,10 +458,10 @@ prompt_pure_setup() {
 	fi
 
 	# show username@host if logged in through SSH
-	[[ "$SSH_CONNECTION" != '' ]] && prompt_pure_username=' %F{242}%n@%m%f'
+	[[ "$SSH_CONNECTION" != '' ]] && prompt_pure_username='%F{242}%n@%m%f'
 
 	# show username@host if root, with username in white
-	[[ $UID -eq 0 ]] && prompt_pure_username=' %F{white}%n%f%F{242}@%m%f'
+	[[ $UID -eq 0 ]] && prompt_pure_username='%F{white}%n%f%F{242}@%m%f'
 
 	# prompt turns red if the previous command didn't exit with 0
 	PROMPT='%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '

--- a/pure.zsh
+++ b/pure.zsh
@@ -57,8 +57,7 @@ prompt_pure_clear_screen() {
 	zle -I
 	# clear screen and move cursor to (0, 0)
 	print -n '\e[2J\e[0;0H'
-	# print preprompt
-	prompt_pure_preprompt_render precmd
+	# Redraw prompt.
 	zle .reset-prompt
 }
 
@@ -127,7 +126,7 @@ prompt_pure_preprompt_render() {
 	# Add git branch and dirty status info.
 	typeset -gA prompt_pure_vcs_info
 	if [[ -n $prompt_pure_vcs_info[branch] ]]; then
-		preprompt_parts+=('%F{$git_color}${prompt_pure_vcs_info[branch]}${prompt_pure_git_dirty}%f')
+		preprompt_parts+=("%F{$git_color}"'${prompt_pure_vcs_info[branch]}${prompt_pure_git_dirty}%f')
 	fi
 	# Git pull/push arrows.
 	if [[ -n $prompt_pure_git_arrows ]]; then

--- a/pure.zsh
+++ b/pure.zsh
@@ -436,6 +436,12 @@ prompt_pure_async_callback() {
 					prompt_pure_git_arrows=$REPLY
 					prompt_pure_preprompt_render
 				fi
+			else
+				# non-zero exit means there is no upstream configured.
+				if [[ -n $prompt_pure_git_arrows ]]; then
+					unset prompt_pure_git_arrows
+					prompt_pure_preprompt_render
+				fi
 			fi
 			;;
 	esac


### PR DESCRIPTION
This is a quick experiment to perform `vcs_info` asynchronously. For anyone trying this out, would appreciate some feedback on how it feels / behaves / problems / etc.

Here we try to detect if the git toplevel has changed so that we can immediately clear the git branch / dirty / arrow status. The problem is, `git rev-parse --show-toplevel` (as used by `vcs_info`) might differ from `$PWD` (e.g. because of symlinks).

To mitigate the above problem to some extent we store the current `$PWD` when entering a git project, this `$PWD` is then used in future comparisons to see if the new `$PWD` is at least a partial match of `$PWD`, if not everything is cleared immediately.

To illustrate what happens:

1. `cd ~/pure`
2. `prompt_pure_async_vcs_info` detects a new git top level `/home/user/pure`, `prompt_pure_vcs_info[pwd]=/home/user/pure`
3. cd `arch`
4. `[[ /home/user/pure/arch =~ ^/home/user/pure ]]` is true, meaning we did not likely change git toplevel, keep the branch / arrow / dirty status

And in the case of first entering a sub folder:

1. `cd ~/pure/arch`
2. `prompt_pure_async_vcs_info` detects a new git top level `/home/user/pure`, `prompt_pure_vcs_info[pwd]=/home/user/pure/arch`
3. cd `..`
4. `[[ /home/user/pure =~ ^/home/user/pure/arch ]]` is not true, so git info is cleared
5. `prompt_pure_async_vcs_info` returns and restores the git info, this time setting `prompt_pure_vcs_info[pwd]=/home/user/pure`

