### PR TITLE
Evaluate $PROMPT at render time

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -368,7 +368,7 @@ prompt_pure_setup() {
 	[[ $UID -eq 0 ]] && prompt_pure_username=' %F{white}%n%f%F{242}@%m%f'
 
 	# prompt turns red if the previous command didn't exit with 0
-	PROMPT="%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f "
+	PROMPT='%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '
 }
 
 prompt_pure_setup "$@"


### PR DESCRIPTION
This allows `$PURE_PROMPT_SYMBOL` to be modified at any point.

![screenshot 2017-01-18 18 09 26](https://cloud.githubusercontent.com/assets/147409/22071889/44b482a6-dda9-11e6-8f72-a326605ad445.png)
