### PR TITLE
Add indication when $SHLVL is > 1

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -136,8 +136,13 @@ prompt_pure_preprompt_render() {
 	local git_color=242
 	[[ -n ${prompt_pure_git_last_dirty_check_timestamp+x} ]] && git_color=red
 
-	# construct preprompt, beginning with path
-	local preprompt="%F{blue}%~%f"
+	# initialize the preprompt
+	local preprompt=
+	# show if we are in a nested shell
+	(( SHLVL > 1 )) && preprompt+="%F{240}${(l:$((SHLVL-1))::!:)}%f "
+	# add current path
+	preprompt+="%F{blue}%~%f"
+
 	# git info
 	preprompt+="%F{$git_color}${vcs_info_msg_0_}${prompt_pure_git_dirty}%f"
 	# git pull/push arrows


### PR DESCRIPTION
Sometimes I find myself wondering if I'm still inside a new instance of a shell or not, as indicated by `$SHLVL`.

If this is something we want to merge, the readme would need to be updated as well (I can do that).

Here's an example of how this would look:
![screenshot 2017-01-18 18 03 38](https://cloud.githubusercontent.com/assets/147409/22071685/92b4c5f2-dda8-11e6-9553-886ca2211012.png)

Thoughts @sindresorhus?