### PR TITLE
Check and set `prompt_opts` when not using `promptinit`

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -342,11 +342,20 @@ prompt_pure_async_callback() {
 }
 
 prompt_pure_setup() {
+	local autoload_name=$1; shift
+
 	# prevent percentage showing up
 	# if output doesn't end with a newline
 	export PROMPT_EOL_MARK=''
 
 	prompt_opts=(subst percent)
+
+	# if autoload_name or eval context differ, pure wasn't autoloaded via
+	# promptinit and we need to take care of setting the options ourselves
+	if [[ $autoload_name != prompt_pure_setup ]] || [[ $zsh_eval_context[-2] != loadautofunc ]]; then
+		# borrowed from `promptinit`, set the pure prompt options
+		setopt noprompt{bang,cr,percent,subst} "prompt${^prompt_opts[@]}"
+	fi
 
 	zmodload zsh/datetime
 	zmodload zsh/zle
@@ -385,4 +394,4 @@ prompt_pure_setup() {
 	PROMPT='%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '
 }
 
-prompt_pure_setup "$@"
+prompt_pure_setup "$0" "$@"


### PR DESCRIPTION
The `prompt_opts` array only has an effect when the theme is loaded via promptinit (`prompt pure`). Previously they were not set when pure was loaded via `source /path/to/pure.zsh` as is the case with e.g. antigen, antibody, etc.

This commit attempts to detect whenever pure is not autoloaded via promptinit and manually sets the options in `prompt_opts`.

Fixes #276.

This PR fixes an issue that was detected due to the change in #274, however, this has been a lurking issue (e.g. our `prompt_opts` not being set for users who `source` pure) for a long time.