### PR TITLE
Add option to show system time in prompt

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -390,8 +390,14 @@ prompt_pure_setup() {
 	# show username@host if root, with username in white
 	[[ $UID -eq 0 ]] && prompt_pure_username=' %F{white}%n%f%F{242}@%m%f'
 
+	# initialize prompt
+	PROMPT=''
+
+	# prepend system time
+	[[ "$PURE_PROMPT_SYSTEM_TIME" != '' ]] && PROMPT+='%F{white}%* '
+
 	# prompt turns red if the previous command didn't exit with 0
-	PROMPT='%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '
+	PROMPT+='%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '
 }
 
 prompt_pure_setup "$0" "$@"

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,10 @@ Time in seconds to delay git dirty checking for large repositories (git status t
 
 Defines the prompt symbol. The default value is `❯`.
 
+### `PURE_PROMPT_SYSTEM_TIME`
+
+Displays system time before the prompt symbol.
+
 ### `PURE_GIT_DOWN_ARROW`
 
 Defines the git down arrow symbol. The default value is `⇣`.


### PR DESCRIPTION
Hello,

I would like to display a system time in front of the prompt symbol like so:

![screen shot 2017-01-25 at 14 24 28](https://cloud.githubusercontent.com/assets/18574468/22292488/cc31a986-e30b-11e6-962e-3d936062fb1e.png)

The only way I found to do this was to edit the `PROMPT` value in the _pure.zsh_. What do you think about adding an option to do this?

If you want to keep your project free from such configurations I fully understand. Would there be another way to customise the prompt and keep up to date with your repo?

Best,
Johannes