### PR TITLE
Link inside pure directory as npm install fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "postinstall": "dest=/usr/local/share/zsh/site-functions; mkdir -p $dest && ln -sf \"$PWD/pure.zsh\" $dest/prompt_pure_setup && ln -sf \"$PWD/async.zsh\" $dest/async || echo 'Could not automagically symlink the prompt. Check out the readme on how to do it manually: https://github.com/sindresorhus/pure#manually'"
+    "postinstall": "PURE_DEST=/usr/local/share/zsh/site-functions npm run --silent postinstall-link && exit 0; PURE_DEST=\"$PWD/functions\" npm run postinstall-link && npm run postinstall-fail-instructions",
+    "postinstall-link": "mkdir -p \"$PURE_DEST\" && ln -sf \"$PWD/pure.zsh\" \"$PURE_DEST/prompt_pure_setup\" && ln -sf \"$PWD/async.zsh\" \"$PURE_DEST/async\"",
+    "postinstall-fail-instructions": "echo \"ERROR: Could not automagically symlink the prompt. Either:\\n1. Check out the readme on how to do it manually: https://github.com/sindresorhus/pure#manually\\n2. Or add the following to your \\`.zshrc\\`:\\n\\n    fpath+=(\\$fpath '$PWD/functions')\""
   },
   "files": [
     "pure.zsh",


### PR DESCRIPTION
Sometimes we do not have write access to the zsh site-functions directory, in those cases we can provide a fallback inside the pure-prompt node module path. The user can then simply add the fallback directory to `$fpath`.

Fixes #282.

---

Here's what a successful install now looks like:

```console
~/Projects/pure master*
❯ npm run postinstall

> pure-prompt@1.5.0 postinstall /Users/mafredri/Projects/zeet/modules/pure
> PURE_DEST=/usr/local/share/zsh/site-functions npm run --silent postinstall-link && exit 0; PURE_DEST="$PWD/functions" npm run postinstall-link && npm run postinstall-fail-instructions

```

And an unsuccessful one:

```console
~/Projects/pure master*
❯ chmod 644 /usr/local/share/zsh/site-functions

~/Projects/pure master*
❯ npm run postinstall

> pure-prompt@1.5.0 postinstall /Users/mafredri/Projects/zeet/modules/pure
> PURE_DEST=/usr/local/share/zsh/site-functions npm run --silent postinstall-link && exit 0; PURE_DEST="$PWD/functions" npm run postinstall-link && npm run postinstall-fail-instructions

ln: /usr/local/share/zsh/site-functions/prompt_pure_setup: Permission denied

> pure-prompt@1.5.0 postinstall-link /Users/mafredri/Projects/zeet/modules/pure
> mkdir -p "$PURE_DEST" && ln -sf "$PWD/pure.zsh" "$PURE_DEST/prompt_pure_setup" && ln -sf "$PWD/async.zsh" "$PURE_DEST/async"


> pure-prompt@1.5.0 postinstall-fail-instructions /Users/mafredri/Projects/zeet/modules/pure
> echo "ERROR: Could not automagically symlink the prompt. Either:\n1. Check out the readme on how to do it manually: https://github.com/sindresorhus/pure#manually\n2. Or add the following to your \`.zshrc\`:\n\n    fpath+=(\$fpath '$PWD/functions')"

ERROR: Could not automagically symlink the prompt. Either:
1. Check out the readme on how to do it manually: https://github.com/sindresorhus/pure#manually
2. Or add the following to your `.zshrc`:

    fpath+=($fpath '/Users/mafredri/Projects/pure/functions')

```

I'm open to suggestions for improving the clarity of the error message / instructions.