### PR TITLE
Fix wrong assumption about promptinit in setup

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -342,20 +342,15 @@ prompt_pure_async_callback() {
 }
 
 prompt_pure_setup() {
-	local autoload_name=$1; shift
-
 	# prevent percentage showing up
 	# if output doesn't end with a newline
 	export PROMPT_EOL_MARK=''
 
 	prompt_opts=(subst percent)
 
-	# if autoload_name or eval context differ, pure wasn't autoloaded via
-	# promptinit and we need to take care of setting the options ourselves
-	if [[ $autoload_name != prompt_pure_setup ]] || [[ $zsh_eval_context[-2] != loadautofunc ]]; then
-		# borrowed from `promptinit`, set the pure prompt options
-		setopt noprompt{bang,cr,percent,subst} "prompt${^prompt_opts[@]}"
-	fi
+	# borrowed from promptinit, sets the prompt options in case pure was not
+	# initialized via promptinit.
+	setopt noprompt{bang,cr,percent,subst} "prompt${^prompt_opts[@]}"
 
 	zmodload zsh/datetime
 	zmodload zsh/zle
@@ -394,4 +389,4 @@ prompt_pure_setup() {
 	PROMPT='%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '
 }
 
-prompt_pure_setup "$0" "$@"
+prompt_pure_setup "$@"


### PR DESCRIPTION
Pure is only autoloaded the first time around, when prompt pure is called a second time, no autoload happens and prompt_pure_setup is called without arguments.

Fixes #290 and partially reverts #277 without breaking the fix for #276.