### PR TITLE
Change * to ᵈ for clarity

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -316,7 +316,7 @@ prompt_pure_async_callback() {
 			if (( code == 0 )); then
 				prompt_pure_git_dirty=
 			else
-				prompt_pure_git_dirty="*"
+				prompt_pure_git_dirty="ᵈ"
 			fi
 
 			[[ $prev_dirty != $prompt_pure_git_dirty ]] && prompt_pure_preprompt_render


### PR DESCRIPTION
Basically what it says on the can: switching out the git dirty symbol ( ᵈ instead of *) should improve clarity about why symbol 'x' has appeared next to the git branch name in the preprompt. It also looks fancier without introducing extra visual distraction :)