### PR TITLE
Helpful hint

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -26,6 +26,8 @@ I have:
 <!--
 Please provide a minimal `.zshrc` that reproduces the issue.
 Try to remove everything that that does not affect the issue, the fewer lines, the better.
+
+Run  `$ cat .zshrc | awk '!/^#/'` to get all the lines from your .zshrc file which don't contain "#".
 -->
 
 ```shell


### PR DESCRIPTION
A helpful hint which makes getting the active (non-comment) components from the .zshrc file much easier.