### PR TITLE
Support configuration of git status timeout via PURE_GIT_STATUS_TIMEOUT and default to 5 seconds.

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -368,7 +368,7 @@ prompt_pure_async_callback() {
 			# When prompt_pure_git_last_dirty_check_timestamp is set, the git info is displayed in a different color.
 			# To distinguish between a "fresh" and a "cached" result, the preprompt is rendered before setting this
 			# variable. Thus, only upon next rendering of the preprompt will the result appear in a different color.
-			(( $exec_time > 2 )) && prompt_pure_git_last_dirty_check_timestamp=$EPOCHSECONDS
+			(( $exec_time > ${PURE_GIT_STATUS_TIMEOUT:-5} )) && prompt_pure_git_last_dirty_check_timestamp=$EPOCHSECONDS
 			;;
 		prompt_pure_async_git_fetch|prompt_pure_async_git_arrows)
 			# prompt_pure_async_git_fetch executes prompt_pure_async_git_arrows

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,11 @@ Set `PURE_GIT_UNTRACKED_DIRTY=0` to not include untracked files in dirtiness che
 
 ### `PURE_GIT_DELAY_DIRTY_CHECK`
 
-Time in seconds to delay git dirty checking for large repositories (git status takes > 2 seconds). The check is performed asynchronously, this is to save CPU. Defaults to `1800` seconds.
+Time in seconds to delay git dirty checking for "large" repositories (where git status may take longer than `PURE_GIT_STATUS_TIMEOUT` seconds). The check is performed asynchronously, this is to save CPU. Defaults to `1800` seconds.
+
+### `PURE_GIT_STATUS_TIMEOUT`
+
+Time in seconds to wait for `git status` to return before considering the repository "large".
 
 ### `PURE_PROMPT_SYMBOL`
 


### PR DESCRIPTION
A large(ish) repository I work with regularly usually returns status within 2 seconds.  But I've found that sometimes under load it takes a bit longer.  This patch allows for configuring the timeout before a repo is considered "large" to avoid an outlier status moving it into PURE_GIT_DELAY_DIRTY_CHECK territory.