### PR TITLE
Ensure no_prompt_subst is set when the expanded prompt is stored

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -185,6 +185,8 @@ prompt_pure_preprompt_render() {
 
 		# redraw prompt (also resets cursor position)
 		zle && zle .reset-prompt
+
+		setopt no_prompt_subst
 	fi
 
 	# store both unexpanded and expanded preprompt for comparison


### PR DESCRIPTION
This is an alternate fix as requested for the exploit mentioned in #304 