### PR TITLE
Add `purer` fork to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -223,7 +223,8 @@ On a default setup, running the command `kldload pty` should do the trick. If yo
 * **Zsh**
   * [therealklanni/purity](https://github.com/therealklanni/purity): a more compact current working directory, important details on the main prompt line, and extra Git indicators.
   * [intelfx/pure](https://github.com/intelfx/pure): Solarized-friendly colors, highly verbose and fully async Git integration
-  * [dfurnes/purer](https://github.com/dfurnes/purer): A compact single-line prompt w/ built in vim-mode indicator.
+  * [dfurnes/purer](https://github.com/dfurnes/purer): A compact single-line prompt with built-in Vim-mode indicator.
+
 
 ## Team
 

--- a/readme.md
+++ b/readme.md
@@ -223,6 +223,7 @@ On a default setup, running the command `kldload pty` should do the trick. If yo
 * **Zsh**
   * [therealklanni/purity](https://github.com/therealklanni/purity): a more compact current working directory, important details on the main prompt line, and extra Git indicators.
   * [intelfx/pure](https://github.com/intelfx/pure): Solarized-friendly colors, highly verbose and fully async Git integration
+  * [dfurnes/purer](https://github.com/dfurnes/purer): A compact single-line prompt w/ built in vim-mode indicator.
 
 ## Team
 


### PR DESCRIPTION
Hello! I made a [custom fork](https://github.com/dfurnes/purer) with few tiny modifications to Pure and wanted to share. All existing functionality should still work the same, but the prompt has been condensed to fit on a single line & I added a "vim-mode" color indicator.

I've published my fork to npm as [`purer-prompt`](https://www.npmjs.com/package/purer-prompt) and tested that it installs nicely alongside Pure. 😄

![screen shot 2017-03-18 at 12 39 59 pm](https://cloud.githubusercontent.com/assets/583202/24074057/12a25362-0bd8-11e7-9cf1-9bf689ac4ae1.png)