### PR TITLE
Add status indicator for Vi mode

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -105,6 +105,16 @@ prompt_pure_string_length_to_var() {
 	typeset -g "${var}"="${length}"
 }
 
+function zle-line-init zle-keymap-select {
+	# store our vi mode
+	if [[ "${KEYMAP}" == 'vicmd' ]]; then
+		prompt_pure_vi_mode="%F{red} N %f"
+	else
+		prompt_pure_vi_mode=""
+	fi
+	prompt_pure_preprompt_render
+}
+
 prompt_pure_preprompt_render() {
 	# store the current prompt_subst setting so that it can be restored later
 	local prompt_subst_status=$options[prompt_subst]
@@ -121,6 +131,8 @@ prompt_pure_preprompt_render() {
 
 	# construct preprompt, beginning with path
 	local preprompt="%F{blue}%~%f"
+	# add vi mode if we use it
+	preprompt+=$prompt_pure_vi_mode
 	# git info
 	preprompt+="%F{$git_color}${vcs_info_msg_0_}${prompt_pure_git_dirty}%f"
 	# git pull/push arrows
@@ -408,6 +420,9 @@ prompt_pure_setup() {
 
 	add-zsh-hook precmd prompt_pure_precmd
 	add-zsh-hook preexec prompt_pure_preexec
+
+	zle -N zle-line-init
+	zle -N zle-keymap-select
 
 	zstyle ':vcs_info:*' enable git
 	zstyle ':vcs_info:*' use-simple true


### PR DESCRIPTION
This is for when a user has `bindkey -v` set to use the vi line editing mode. If they have it set, it would be nice to let the user know when they are in command mode as opposed to insert mode.
E.G.:
![screen shot 2017-03-18 at 7 33 07 pm](https://cloud.githubusercontent.com/assets/3675702/24077643/d12fe00e-0c11-11e7-831f-ec0be736f5bc.png)

Pressing escape toggles between normal(command)/insert mode in real time and the red N updates with it.

This will only show up if you are in command mode, which will only happen when you have enabled vi editing.