### PR TITLE
Restore old virtualenv behavior by only modifying preprompt

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -138,21 +138,23 @@ prompt_pure_preprompt_render() {
 	# Execution time.
 	[[ -n $prompt_pure_cmd_exec_time ]] && preprompt_parts+=('%F{yellow}${prompt_pure_cmd_exec_time}%f')
 
-	# Cleanup prompt (remove preprompt).
-	local trim_preprompt
-	trim_preprompt="${PROMPT#*\$PROMPT_PURE_PREPROMPT_BEGIN}"
-	trim_preprompt="${trim_preprompt%\$PROMPT_PURE_PREPROMPT_END*}"
-	PROMPT=${PROMPT/\$PROMPT_PURE_PREPROMPT_BEGIN${trim_preprompt}\$PROMPT_PURE_PREPROMPT_END}
+	local cleaned_ps1=$PROMPT
+	local -H MATCH
+	if [[ $PROMPT =~ $prompt_newline ]]; then
+		# When the prompt contains newlines, we keep everything before the first
+		# and after the last newline, leaving us with everything except the
+		# preprompt. This is needed because some software prefixes the prompt
+		# (e.g. virtualenv).
+		cleaned_ps1=${PROMPT%%${prompt_newline}*}${PROMPT##*${prompt_newline}}
+	fi
 
 	# Construct the new prompt with a clean preprompt.
 	local -ah ps1
 	ps1=(
-		'$PROMPT_PURE_PREPROMPT_BEGIN'
 		$prompt_newline           # Initial newline, for spaciousness.
 		${(j. .)preprompt_parts}  # Join parts, space separated.
 		$prompt_newline           # Separate preprompt and prompt.
-		'$PROMPT_PURE_PREPROMPT_END'
-		$PROMPT
+		$cleaned_ps1
 	)
 
 	PROMPT="${(j..)ps1}"

--- a/pure.zsh
+++ b/pure.zsh
@@ -138,16 +138,21 @@ prompt_pure_preprompt_render() {
 	# Execution time.
 	[[ -n $prompt_pure_cmd_exec_time ]] && preprompt_parts+=('%F{yellow}${prompt_pure_cmd_exec_time}%f')
 
-	local -ah ps1
+	# Cleanup prompt (remove preprompt).
+	local trim_preprompt
+	trim_preprompt="${PROMPT#*\$PROMPT_PURE_PREPROMPT_BEGIN}"
+	trim_preprompt="${trim_preprompt%\$PROMPT_PURE_PREPROMPT_END*}"
+	PROMPT=${PROMPT/\$PROMPT_PURE_PREPROMPT_BEGIN${trim_preprompt}\$PROMPT_PURE_PREPROMPT_END}
 
-	# Construct the new prompt, containing preprompt.
-	PROMPT=${PROMPT//$prompt_newline/$'\n'}
-	ps1=(${(f)PROMPT})  # Split on newline.
+	# Construct the new prompt with a clean preprompt.
+	local -ah ps1
 	ps1=(
+		'$PROMPT_PURE_PREPROMPT_BEGIN'
 		$prompt_newline           # Initial newline, for spaciousness.
 		${(j. .)preprompt_parts}  # Join parts, space separated.
 		$prompt_newline           # Separate preprompt and prompt.
-		$ps1[-1]                  # Keep last part of the prompt.
+		'$PROMPT_PURE_PREPROMPT_END'
+		$PROMPT
 	)
 
 	PROMPT="${(j..)ps1}"


### PR DESCRIPTION
It seems 4cdd0cf4f48d0c2064700c4fc60083bc0b3f6693 prevents some previous use-cases (e.g. with regard to virtualenvs: #320).

~~This PR restricts prompt modifications to only what is present in the preprompt, by surrounding the preprompt in non-existent variables (that prints empty). I'm not perfectly happy with this approach as it feels a bit hackish, but it should be good enough for now.~~ Simplified in d8322b7.

There is an alternative way to go about this as well, as proposed in the issue https://github.com/sindresorhus/pure/issues/320#issuecomment-298942782. However, that approach is not as versatile as this PR. This PR should fix all possible cases of appending/prepending to prompt by other shell scripts.

Even if this PR is merged, we might still want to implement the patch from #320 once we properly decide on how to go forward with virtualenvs.