### PR TITLE
Remove deprecated clear-screen ZLE widget

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -52,15 +52,6 @@ prompt_pure_check_cmd_exec_time() {
 	}
 }
 
-prompt_pure_clear_screen() {
-	# enable output to terminal
-	zle -I
-	# clear screen and move cursor to (0, 0)
-	print -n '\e[2J\e[0;0H'
-	# Redraw prompt.
-	zle .reset-prompt
-}
-
 prompt_pure_set_title() {
 	# emacs terminal does not support settings the title
 	(( ${+EMACS} )) && return
@@ -455,13 +446,6 @@ prompt_pure_setup() {
 
 	add-zsh-hook precmd prompt_pure_precmd
 	add-zsh-hook preexec prompt_pure_preexec
-
-	# if the user has not registered a custom zle widget for clear-screen,
-	# override the builtin one so that the preprompt is displayed correctly when
-	# ^L is issued.
-	if [[ $widgets[clear-screen] == 'builtin' ]]; then
-		zle -N clear-screen prompt_pure_clear_screen
-	fi
 
 	# show username@host if logged in through SSH
 	[[ "$SSH_CONNECTION" != '' ]] && prompt_pure_username='%F{242}%n@%m%f'

--- a/readme.md
+++ b/readme.md
@@ -187,12 +187,6 @@ zplug sindresorhus/pure, use:pure.zsh, from:github, as:theme
 
 ## FAQ
 
-### My preprompt is missing when I clear the screen with Ctrl+L
-
-Pure doesn't register its custom *clear-screen* widget if it has been previously modified. If you haven't registered your own zle widget with `zle -N clear-screen custom-clear-screen` it might have been done by third-party modules. For example `zsh-syntax-highlighting` and `zsh-history-substring-search` are known to do this and they should for that reason be **the very last thing** in your `.zshrc` (as pointed out in their documentation).
-
-To find out the culprit that is overriding your *clear-screen* widget, you can run the following command: `zle -l | grep clear-screen`.
-
 ### I am stuck in a shell loop in my terminal that ask me to authenticate. What should I do ?
 
 [This is a known issue](https://github.com/sindresorhus/pure/issues/76).


### PR DESCRIPTION
This is no longer needed because `$PROMPT` contains the entire prompt (including preprompt) since 4cdd0cf4f48d0c2064700c4fc60083bc0b3f6693.

Mention in readme FAQ was also removed.