### PR TITLE
Improve the style of the continuation prompt (PS2)

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -642,6 +642,7 @@ prompt_pure_setup() {
 
 	prompt_pure_state_setup
 
+	zle -N prompt-pure-reset-prompt prompt_pure_reset_prompt
 	zle -N prompt_pure_update_vim_prompt_widget
 	zle -N prompt_pure_reset_vim_prompt_widget
 	if (( $+functions[add-zle-hook-widget] )); then

--- a/pure.zsh
+++ b/pure.zsh
@@ -651,11 +651,12 @@ prompt_pure_setup() {
 
 	# if a virtualenv is activated, display it in grey
 	PROMPT='%(12V.%F{242}%12v%f .)'
-	PROMPT2='%(12V.%F{242}%12v%f .)'
 
 	# prompt turns red if the previous command didn't exit with 0
 	PROMPT+='%(?.%F{magenta}.%F{red})${prompt_pure_state[prompt]}%f '
-	PROMPT2+='%F{242}%_%f %(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '
+
+	# Indicate continuation prompt by ... and use a darker color for it.
+	PROMPT2='%F{242}... %(1_.%_ .%_)%f%(?.%F{magenta}.%F{red})${prompt_pure_state[prompt]}%f '
 
 	# Store prompt expansion symbols for in-place expansion via (%). For
 	# some reason it does not work without storing them in a variable first.

--- a/pure.zsh
+++ b/pure.zsh
@@ -103,6 +103,16 @@ prompt_pure_preexec() {
 	export VIRTUAL_ENV_DISABLE_PROMPT=${VIRTUAL_ENV_DISABLE_PROMPT:-12}
 }
 
+prompt_pure_reset_prompt() {
+	if [[ $CONTEXT = cont ]]; then
+		# When the context is cont, PS2 is active and calling
+		# reset-prompt will have no effect on PS1.
+		return
+	fi
+
+	zle .reset-prompt
+}
+
 prompt_pure_preprompt_render() {
 	setopt localoptions noshwordsplit
 
@@ -160,7 +170,7 @@ prompt_pure_preprompt_render() {
 		print
 	elif [[ $prompt_pure_last_prompt != $expanded_prompt ]]; then
 		# Redraw the prompt.
-		zle && zle .reset-prompt
+		zle && zle prompt-pure-reset-prompt
 	fi
 
 	typeset -g prompt_pure_last_prompt=$expanded_prompt
@@ -641,9 +651,11 @@ prompt_pure_setup() {
 
 	# if a virtualenv is activated, display it in grey
 	PROMPT='%(12V.%F{242}%12v%f .)'
+	PROMPT2='%(12V.%F{242}%12v%f .)'
 
 	# prompt turns red if the previous command didn't exit with 0
 	PROMPT+='%(?.%F{magenta}.%F{red})${prompt_pure_state[prompt]}%f '
+	PROMPT2+='%F{242}%_%f %(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '
 
 	# Store prompt expansion symbols for in-place expansion via (%). For
 	# some reason it does not work without storing them in a variable first.


### PR DESCRIPTION
I've always thought the PS2 looked a bit out-of-place in Pure and I wanted to improve it, so I gave it a whack.

This PR does two things:

* Stylize the PS2 prompt with colors and the Pure prompt symbol `❯` (also includes the exit status in the PS2 prompt)
* Prevent prompt updates when PS2 is displayed (it's not possible to update PS1 with `reset-prompt` at this point)

This is what it looks like now:

<img width="489" alt="screenshot 2017-05-07 15 08 24" src="https://cloud.githubusercontent.com/assets/147409/25780838/94706e3e-3337-11e7-807a-3616a5e11b28.png">

A variation I tried was to include `❯` in front as well:

<img width="639" alt="screenshot 2017-05-07 15 06 25" src="https://cloud.githubusercontent.com/assets/147409/25780843/a3b538c0-3337-11e7-9838-b7dcb2172824.png">

But while looking OK was just not quite there.

I also looked at a bunch of different arrows and tried them out but couldn't find a good fit, closest ones were `↳` (but it did not quite align in the middle of the text, thus looking misaligned) and `⥅`. Neither of which I felt added value.

### Considerations

* Do we need to consider how this looks when virtualenvs (#254) are activated if we were to show them in the same manner?
* We could limit the number of entries (`cmdand`, etc.) by using `%N_` where `N` is the max number of entries, but I can't think of a very good reason to do this, at least it has never been an issue for me