### PR TITLE
Add support for python virtualenv

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -176,6 +176,10 @@ prompt_pure_precmd() {
 	# preform async git dirty check and fetch
 	prompt_pure_async_tasks
 
+	# store name of virtualenv in psvar if activated
+	psvar[12]=
+	[[ -n $VIRTUAL_ENV ]] && psvar[12]="${VIRTUAL_ENV:t}"
+
 	# print the preprompt
 	prompt_pure_preprompt_render "precmd"
 
@@ -425,6 +429,9 @@ prompt_pure_setup() {
 	# Prevent percentage showing up if output doesn't end with a newline.
 	export PROMPT_EOL_MARK=''
 
+	# disallow python virtualenvs from updating the prompt
+	export VIRTUAL_ENV_DISABLE_PROMPT=1
+
 	prompt_opts=(subst percent)
 
 	# borrowed from promptinit, sets the prompt options in case pure was not
@@ -453,8 +460,11 @@ prompt_pure_setup() {
 	# show username@host if root, with username in white
 	[[ $UID -eq 0 ]] && prompt_pure_username='%F{white}%n%f%F{242}@%m%f'
 
+	# if a virtualenv is activated, display it in grey
+	PROMPT='%(12V.%F{242}${psvar[12]}%f .)'
+
 	# prompt turns red if the previous command didn't exit with 0
-	PROMPT='%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '
+	PROMPT+='%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '
 }
 
 prompt_pure_setup "$@"

--- a/pure.zsh
+++ b/pure.zsh
@@ -461,7 +461,7 @@ prompt_pure_setup() {
 	[[ $UID -eq 0 ]] && prompt_pure_username='%F{white}%n%f%F{242}@%m%f'
 
 	# if a virtualenv is activated, display it in grey
-	PROMPT='%(12V.%F{242}${psvar[12]}%f .)'
+	PROMPT='%(12V.%F{242}%12v%f .)'
 
 	# prompt turns red if the previous command didn't exit with 0
 	PROMPT+='%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '


### PR DESCRIPTION
When a virtualenv is activated, the name of the virtualenv will be displayed right before the `❯` symbol.

<img width="467" alt="screen shot 2017-05-08 at 20 42 24" src="https://cloud.githubusercontent.com/assets/3471625/25819660/f2558898-342e-11e7-970a-39f98fcd13a0.png">

**About the code**
I haven't really done anything fancy. I ended up just making a couple of tweaks to the patch @mafredri posted in [#320 (comment)](https://github.com/sindresorhus/pure/issues/320#issuecomment-298942782).

**P.S.** Any particular reason why you (@mafredri) chose the 12th position in `psvar`? I never really understood why, but I figured that there's probably a good reason 😛 