### PR TITLE
Use glob instead of regex for dir matching

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -286,7 +286,7 @@ prompt_pure_async_tasks() {
 	typeset -gA prompt_pure_vcs_info
 
 	local -H MATCH
-	if ! [[ $PWD =~ ^$prompt_pure_vcs_info[pwd] ]]; then
+	if ! [[ $PWD = ${prompt_pure_vcs_info[pwd]}* ]]; then
 		# stop any running async jobs
 		async_flush_jobs "prompt_pure"
 
@@ -362,7 +362,7 @@ prompt_pure_async_callback() {
 			if [[ $info[top] = $prompt_pure_vcs_info[top] ]]; then
 				# if stored pwd is part of $PWD, $PWD is shorter and likelier
 				# to be toplevel, so we update pwd
-				if [[ $prompt_pure_vcs_info[pwd] =~ ^$PWD ]]; then
+				if [[ $prompt_pure_vcs_info[pwd] = ${PWD}* ]]; then
 					prompt_pure_vcs_info[pwd]=$PWD
 				fi
 			else


### PR DESCRIPTION
Discovered this issue by accident.

Sometimes directory names might contain characters that cause an invalid regex, for example, cd:ing into the directory `test[` would result in the following error:

```
prompt_pure_async_callback:21: failed to compile regex: brackets ([ ]) not balanced
```

We avoid this problem by using globbing instead of regex when checking if the path matches.

**Sidenote:** I'm a bit worried that there could be some zsh option (or combination of options) that causes this to misbehave, but I can't think of any.