### PR TITLE
Add back the prompt_sp option for zsh >= 5.4.1

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -432,11 +432,11 @@ prompt_pure_setup() {
 	# disallow python virtualenvs from updating the prompt
 	export VIRTUAL_ENV_DISABLE_PROMPT=1
 
-	prompt_opts=(subst percent)
+	prompt_opts=(sp subst percent)
 
 	# borrowed from promptinit, sets the prompt options in case pure was not
 	# initialized via promptinit.
-	setopt noprompt{bang,cr,percent,subst} "prompt${^prompt_opts[@]}"
+	setopt noprompt{bang,cr,percent,sp,subst} "prompt${^prompt_opts[@]}"
 
 	if [[ -z $prompt_newline ]]; then
 		# This variable needs to be set, usually set by promptinit.


### PR DESCRIPTION
In 5.4.1, this option was reset between prompts, so to retain the
previous default behavior, this should be added back.

This was the change which caused it to be reset: https://github.com/zsh-users/zsh/commit/43e55a9bcd2c90124a751f2597d2f33cb6e3c042#diff-bb10d67e7a8561b66a53a805f3c77a40R233

This is the documentation on the option itself: http://zsh.sourceforge.net/Doc/Release/Options.html#Prompting