### PR TITLE
Avoid implicit global var creation and cleanup

### DIFF
--- a/async.zsh
+++ b/async.zsh
@@ -3,20 +3,20 @@
 #
 # zsh-async
 #
-# version: 1.5.0
+# version: 1.5.2
 # author: Mathias Fredriksson
 # url: https://github.com/mafredri/zsh-async
 #
 
 # Produce debug output from zsh-async when set to 1.
-ASYNC_DEBUG=${ASYNC_DEBUG:-0}
+typeset -g ASYNC_DEBUG=${ASYNC_DEBUG:-0}
 
 # Wrapper for jobs executed by the async worker, gives output in parseable format with execution time
 _async_job() {
 	# Disable xtrace as it would mangle the output.
 	setopt localoptions noxtrace
 
-	# Store start time as double precision (+E disables scientific notation)
+	# Store start time for job.
 	float -F duration=$EPOCHREALTIME
 
 	# Run the command and capture both stdout (`eval`) and stderr (`cat`) in
@@ -204,7 +204,7 @@ _async_worker() {
 # 	$5 = resulting stderr from execution
 #
 async_process_results() {
-	setopt localoptions noshwordsplit
+	setopt localoptions unset noshwordsplit noksharrays noposixidentifiers noposixstrings
 
 	local worker=$1
 	local callback=$2
@@ -279,7 +279,7 @@ _async_zle_watcher() {
 # 	async_job <worker_name> <my_function> [<function_params>]
 #
 async_job() {
-	setopt localoptions noshwordsplit
+	setopt localoptions noshwordsplit noksharrays noposixidentifiers noposixstrings
 
 	local worker=$1; shift
 
@@ -289,13 +289,15 @@ async_job() {
 		cmd=(${(q)cmd})  # Quote special characters in multi argument commands.
 	fi
 
-	zpty -w $worker $cmd$'\0'
+	# Quote the cmd in case RC_EXPAND_PARAM is set.
+	zpty -w $worker "$cmd"$'\0'
 }
 
 # This function traps notification signals and calls all registered callbacks
 _async_notify_trap() {
 	setopt localoptions noshwordsplit
 
+	local k
 	for k in ${(k)ASYNC_CALLBACKS}; do
 		async_process_results $k ${ASYNC_CALLBACKS[$k]} trap
 	done
@@ -442,7 +444,7 @@ async_start_worker() {
 async_stop_worker() {
 	setopt localoptions noshwordsplit
 
-	local ret=0
+	local ret=0 worker k v
 	for worker in $@; do
 		# Find and unregister the zle handler for the worker
 		for k v in ${(@kv)ASYNC_PTYS}; do
@@ -470,14 +472,14 @@ async_stop_worker() {
 #
 async_init() {
 	(( ASYNC_INIT_DONE )) && return
-	ASYNC_INIT_DONE=1
+	typeset -g ASYNC_INIT_DONE=1
 
 	zmodload zsh/zpty
 	zmodload zsh/datetime
 
 	# Check if zsh/zpty returns a file descriptor or not,
 	# shell must also be interactive with zle enabled.
-	ASYNC_ZPTY_RETURNS_FD=0
+	typeset -g ASYNC_ZPTY_RETURNS_FD=0
 	[[ -o interactive ]] && [[ -o zle ]] && {
 		typeset -h REPLY
 		zpty _async_test :

--- a/pure.zsh
+++ b/pure.zsh
@@ -161,6 +161,7 @@ prompt_pure_preprompt_render() {
 prompt_pure_precmd() {
 	# check exec time and store it in a variable
 	prompt_pure_check_cmd_exec_time
+	unset prompt_pure_cmd_timestamp
 
 	# shows the full path in the title
 	prompt_pure_set_title 'expand-prompt' '%~'

--- a/pure.zsh
+++ b/pure.zsh
@@ -46,8 +46,8 @@ prompt_pure_human_time_to_var() {
 prompt_pure_check_cmd_exec_time() {
 	integer elapsed
 	(( elapsed = EPOCHSECONDS - ${prompt_pure_cmd_timestamp:-$EPOCHSECONDS} ))
-	prompt_pure_cmd_exec_time=
-	(( elapsed > ${PURE_CMD_MAX_EXEC_TIME:=5} )) && {
+	typeset -g prompt_pure_cmd_exec_time=
+	(( elapsed > ${PURE_CMD_MAX_EXEC_TIME:-5} )) && {
 		prompt_pure_human_time_to_var $elapsed "prompt_pure_cmd_exec_time"
 	}
 }
@@ -80,7 +80,7 @@ prompt_pure_preexec() {
 		fi
 	fi
 
-	prompt_pure_cmd_timestamp=$EPOCHSECONDS
+	typeset -g prompt_pure_cmd_timestamp=$EPOCHSECONDS
 
 	# shows the current dir and executed command in the title while a process is active
 	prompt_pure_set_title 'ignore-escape' "$PWD:t: $2"
@@ -98,10 +98,6 @@ prompt_pure_string_length_to_var() {
 
 prompt_pure_preprompt_render() {
 	setopt localoptions noshwordsplit
-
-	# Check that no command is currently running, the preprompt will otherwise
-	# be rendered in the wrong place.
-	[[ -n ${prompt_pure_cmd_timestamp+x} ]] && [[ $1 != precmd ]] && return
 
 	# Set color for git branch/dirty status, change color if dirty checking has
 	# been delayed.
@@ -159,16 +155,12 @@ prompt_pure_preprompt_render() {
 		zle && zle .reset-prompt
 	fi
 
-	prompt_pure_last_prompt=$expanded_prompt
+	typeset -g prompt_pure_last_prompt=$expanded_prompt
 }
 
 prompt_pure_precmd() {
 	# check exec time and store it in a variable
 	prompt_pure_check_cmd_exec_time
-
-	# by making sure that prompt_pure_cmd_timestamp is defined here the async functions are prevented from interfering
-	# with the initial preprompt rendering
-	prompt_pure_cmd_timestamp=
 
 	# shows the full path in the title
 	prompt_pure_set_title 'expand-prompt' '%~'
@@ -182,9 +174,6 @@ prompt_pure_precmd() {
 
 	# print the preprompt
 	prompt_pure_preprompt_render "precmd"
-
-	# remove the prompt_pure_cmd_timestamp, indicating that precmd has completed
-	unset prompt_pure_cmd_timestamp
 }
 
 prompt_pure_async_git_aliases() {
@@ -280,7 +269,7 @@ prompt_pure_async_tasks() {
 	((!${prompt_pure_async_init:-0})) && {
 		async_start_worker "prompt_pure" -u -n
 		async_register_callback "prompt_pure" prompt_pure_async_callback
-		prompt_pure_async_init=1
+		typeset -g prompt_pure_async_init=1
 	}
 
 	typeset -gA prompt_pure_vcs_info
@@ -314,7 +303,7 @@ prompt_pure_async_refresh() {
 	if [[ -z $prompt_pure_git_fetch_pattern ]]; then
 		# we set the pattern here to avoid redoing the pattern check until the
 		# working three has changed. pull and fetch are always valid patterns.
-		prompt_pure_git_fetch_pattern="pull|fetch"
+		typeset -g prompt_pure_git_fetch_pattern="pull|fetch"
 		async_job "prompt_pure" prompt_pure_async_git_aliases $working_tree
 	fi
 
@@ -390,9 +379,9 @@ prompt_pure_async_callback() {
 		prompt_pure_async_git_dirty)
 			local prev_dirty=$prompt_pure_git_dirty
 			if (( code == 0 )); then
-				prompt_pure_git_dirty=
+				unset prompt_pure_git_dirty
 			else
-				prompt_pure_git_dirty="*"
+				typeset -g prompt_pure_git_dirty="*"
 			fi
 
 			[[ $prev_dirty != $prompt_pure_git_dirty ]] && prompt_pure_preprompt_render


### PR DESCRIPTION
This PR will prevent `setopt warn_create_global` from showing errors and give the reader a better understanding of how the variable is used (global or local scope).

Another thing that snuck in:

The preprompt render guard logic of `prompt_pure_cmd_timestamp` was also removed because this can no longer happen. If a command is running, ZLE will not be active and `zle reset-prompt` will do nothing.

Closes #345.

**Footnote:** Arguably, `warn_create_global` is IMO not reason enough to make this change, but I believe the explicit global declarations are useful to the reader.