### PR TITLE
More custom colors for the theme

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -324,6 +324,12 @@ prompt_pure_async_callback() {
 }
 
 prompt_pure_setup() {
+  # Define colors for BSD ls.
+  export LSCOLORS='exfxcxdxbxGxDxabagacad'
+
+  # Define colors for the completion system.
+  export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=36;01:cd=33;01:su=31;40;07:sg=36;40;07:tw=32;40;07:ow=33;40;07:'
+
 	# prevent percentage showing up
 	# if output doesn't end with a newline
 	export PROMPT_EOL_MARK=''

--- a/pure.zsh
+++ b/pure.zsh
@@ -137,7 +137,7 @@ prompt_pure_preprompt_render() {
 	[[ -n ${prompt_pure_git_last_dirty_check_timestamp+x} ]] && git_color=red
 
 	# construct preprompt, beginning with path
-	local preprompt="%F{blue}%~%f"
+	local preprompt="%F{${PURE_PREPROMPT_COLOR:-blue}}%~%f"
 	# git info
 	preprompt+="%F{$git_color}${vcs_info_msg_0_}${prompt_pure_git_dirty}%f"
 	# git pull/push arrows
@@ -364,7 +364,7 @@ prompt_pure_setup() {
 	[[ $UID -eq 0 ]] && prompt_pure_username=' %F{white}%n%f%F{242}@%m%f'
 
 	# prompt turns red if the previous command didn't exit with 0
-	PROMPT="%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f "
+	PROMPT="%(?.%F{${PURE_SUCCESS_COLOR:-magenta}}.%F{${PURE_ERROR_COLOR:-red}})${PURE_PROMPT_SYMBOL:-❯}%f "
 }
 
 prompt_pure_setup "$@"

--- a/pure.zsh
+++ b/pure.zsh
@@ -386,12 +386,6 @@ prompt_pure_async_callback() {
 }
 
 prompt_pure_setup() {
-  # Define colors for BSD ls.
-  export LSCOLORS='exfxcxdxbxGxDxabagacad'
-
-  # Define colors for the completion system.
-  export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=36;01:cd=33;01:su=31;40;07:sg=36;40;07:tw=32;40;07:ow=33;40;07:'
-
 	# prevent percentage showing up
 	# if output doesn't end with a newline
 	export PROMPT_EOL_MARK=''

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,18 @@ Time in seconds to delay git dirty checking for large repositories (git status t
 
 Defines the prompt symbol. The default value is `❯`.
 
+### `PURE_PREPROMPT_COLOR`
+
+Defines the color for the prepromt line. The default value is `blue`.
+
+### `PURE_SUCCESS_COLOR`
+
+Defines the color for the prompt with exit code `0`. The default value is `magenta`.
+
+### `PURE_ERROR_COLOR`
+
+Defines the color for the prompt with exit code different than `0`. The default value is `red`.
+
 ### `PURE_GIT_DOWN_ARROW`
 
 Defines the git down arrow symbol. The default value is `⇣`.


### PR DESCRIPTION
Parametrised some colors of the theme for more customisation.  

`PURE_PREPROMPT_COLOR`  
Defines the color for the prepromt line. The default value is `blue`.  

`PURE_SUCCESS_COLOR`  
Defines the color for the prompt with exit code `0`. The default value is `magenta`.  

`PURE_ERROR_COLOR`  
Defines the color for the prompt with exit code different than `0`. The default value is `red`.  