### PR TITLE
Add the possibility to disable the virtual env prompt display.

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -178,7 +178,9 @@ prompt_pure_precmd() {
 
 	# store name of virtualenv in psvar if activated
 	psvar[12]=
-	[[ -n $VIRTUAL_ENV ]] && psvar[12]="${VIRTUAL_ENV:t}"
+	if [ -z "${PURE_VIRTUAL_ENV_DISABLE_PROMPT-}" ] ; then
+		[[ -n $VIRTUAL_ENV ]] && psvar[12]="${VIRTUAL_ENV:t}"
+	fi
 
 	# print the preprompt
 	prompt_pure_preprompt_render "precmd"
@@ -430,7 +432,13 @@ prompt_pure_setup() {
 	export PROMPT_EOL_MARK=''
 
 	# disallow python virtualenvs from updating the prompt
-	export VIRTUAL_ENV_DISABLE_PROMPT=1
+	if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT-}" ]; then
+		# it was not set. set it to only have pure modify the shell.
+		export VIRTUAL_ENV_DISABLE_PROMPT=1
+	else
+		# it was already set. also disable pure display.
+		export PURE_VIRTUAL_ENV_DISABLE_PROMPT=1
+	fi
 
 	prompt_opts=(subst percent)
 

--- a/pure.zsh
+++ b/pure.zsh
@@ -176,10 +176,25 @@ prompt_pure_precmd() {
 	# preform async git dirty check and fetch
 	prompt_pure_async_tasks
 
-	# store name of virtualenv in psvar if activated
-	psvar[12]=
-	if [ -z "${PURE_VIRTUAL_ENV_DISABLE_PROMPT-}" ] ; then
-		[[ -n $VIRTUAL_ENV ]] && psvar[12]="${VIRTUAL_ENV:t}"
+  # handling of virtualenv
+  # The following states of the environment variable
+  # $VIRTUAL_ENV_DISABLE_PROMPT are used:
+  # - undefined or 0: set it to 2,
+  # - set and >0: set it to 3,
+  # - 2: show virtual env,
+  # - 3: don't show virtual env.
+  # Thus, the variable space remains uncluttered.
+  psvar[12]=
+	if [[ ! -n "${VIRTUAL_ENV_DISABLE_PROMPT}"  ||
+        "${VIRTUAL_ENV_DISABLE_PROMPT}" -eq 0 ]]; then
+		  # it was not set. set it to only have pure modify the shell.
+		  export VIRTUAL_ENV_DISABLE_PROMPT=2
+	elif [[ "${VIRTUAL_ENV_DISABLE_PROMPT}" -eq 1 ]]; then
+		  export VIRTUAL_ENV_DISABLE_PROMPT=3
+  fi
+  if [[ "${VIRTUAL_ENV_DISABLE_PROMPT}" -eq 2 ]]; then
+	    # store name of virtualenv in psvar if activated
+      psvar[12]="${VIRTUAL_ENV:t}"
 	fi
 
 	# print the preprompt
@@ -430,15 +445,6 @@ prompt_pure_async_callback() {
 prompt_pure_setup() {
 	# Prevent percentage showing up if output doesn't end with a newline.
 	export PROMPT_EOL_MARK=''
-
-	# disallow python virtualenvs from updating the prompt
-	if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT-}" ]; then
-		# it was not set. set it to only have pure modify the shell.
-		export VIRTUAL_ENV_DISABLE_PROMPT=1
-	else
-		# it was already set. also disable pure display.
-		export PURE_VIRTUAL_ENV_DISABLE_PROMPT=1
-	fi
 
 	prompt_opts=(subst percent)
 


### PR DESCRIPTION
This PR checks whether `VIRTUAL_ENV_DISABLE_PROMPT` is set before the setup is called and if so, honors it. This is implemented by setting the additional `PURE_VIRTUAL_ENV_DISABLE_PROMPT` variable, which disables the display.

This leads to a transparent and consistent behavior with what is expected if the user sets `VIRTUAL_ENV_DISABLE_PROMPT`. In my use case, I load a certain virtual env by default and do not want to have this very name always displayed.