### PR TITLE
Add sp to the prompt_opts array

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -432,11 +432,11 @@ prompt_pure_setup() {
 	# disallow python virtualenvs from updating the prompt
 	export VIRTUAL_ENV_DISABLE_PROMPT=1
 
-	prompt_opts=(subst percent)
+	prompt_opts=(percent sp subst)
 
 	# borrowed from promptinit, sets the prompt options in case pure was not
 	# initialized via promptinit.
-	setopt noprompt{bang,cr,percent,subst} "prompt${^prompt_opts[@]}"
+	setopt noprompt{bang,cr,percent,sp,subst} "prompt${^prompt_opts[@]}"
 
 	if [[ -z $prompt_newline ]]; then
 		# This variable needs to be set, usually set by promptinit.


### PR DESCRIPTION
to fix `nopromptsp` being set in zsh 5.4, which hides the last line of outputs without a LF character at the end, like

    echo -n "bla"

With zsh starting at version 5.4, when using the `prompt_opts` array, `nopromptsp` will be set unless the array contains a `sp`. This was introduced in zsh at https://github.com/zsh-users/zsh/commit/43e55a9bcd2c90124a751f2597d2f33cb6e3c042#diff-bb10d67e7a8561b66a53a805f3c77a40R233

See https://github.com/Eriner/zim/issues/209