### PR TITLE
Prevent multiple prompt resets in one execution cycle

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -340,7 +340,8 @@ prompt_pure_check_git_arrows() {
 
 prompt_pure_async_callback() {
 	setopt localoptions noshwordsplit
-	local job=$1 code=$2 output=$3 exec_time=$4
+	local job=$1 code=$2 output=$3 exec_time=$4 next_pending=$6
+	local do_render=0
 
 	case $job in
 		prompt_pure_async_vcs_info)
@@ -371,7 +372,7 @@ prompt_pure_async_callback() {
 			prompt_pure_vcs_info[branch]=$info[branch]
 			prompt_pure_vcs_info[top]=$info[top]
 
-			prompt_pure_preprompt_render
+			do_render=1
 			;;
 		prompt_pure_async_git_aliases)
 			if [[ -n $output ]]; then
@@ -387,7 +388,7 @@ prompt_pure_async_callback() {
 				typeset -g prompt_pure_git_dirty="*"
 			fi
 
-			[[ $prev_dirty != $prompt_pure_git_dirty ]] && prompt_pure_preprompt_render
+			[[ $prev_dirty != $prompt_pure_git_dirty ]] && do_render=1
 
 			# When prompt_pure_git_last_dirty_check_timestamp is set, the git info is displayed in a different color.
 			# To distinguish between a "fresh" and a "cached" result, the preprompt is rendered before setting this
@@ -402,7 +403,7 @@ prompt_pure_async_callback() {
 				prompt_pure_check_git_arrows ${(ps:\t:)output}
 				if [[ $prompt_pure_git_arrows != $REPLY ]]; then
 					typeset -g prompt_pure_git_arrows=$REPLY
-					prompt_pure_preprompt_render
+					do_render=1
 				fi
 			elif (( code != 99 )); then
 				# Unless the exit code is 99, prompt_pure_async_git_arrows
@@ -410,11 +411,19 @@ prompt_pure_async_callback() {
 				# upstream configured.
 				if [[ -n $prompt_pure_git_arrows ]]; then
 					unset prompt_pure_git_arrows
-					prompt_pure_preprompt_render
+					do_render=1
 				fi
 			fi
 			;;
 	esac
+
+	if (( next_pending )); then
+		(( do_render )) && typeset -g prompt_pure_async_render_requested=1
+		return
+	fi
+
+	[[ ${prompt_pure_async_render_requested:-$do_render} = 1 ]] && prompt_pure_preprompt_render
+	unset prompt_pure_async_render_requested
 }
 
 prompt_pure_setup() {


### PR DESCRIPTION
The prompt ends up in a weird state when `zle reset-prompt` is called multiple times during one execution cycle. This can happen when multiple async tasks finish at nearly the same time. What happened here is that `async_process_results` called `prompt_pure_async_callback` multiple
times during it's execution. In turn, `prompt_pure_async_callback` did multiple calls to `zle reset-prompt`. My theory is that ZLE ends up in a weird state that is reset after all the current code has completed executing.

This behavior is observable when the prompt "moves upwards" and erases previous lines in the terminal.

Fixes #356.