### PR TITLE
Add optional prompt prefix if root

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -464,6 +464,11 @@ prompt_pure_setup() {
 	# if a virtualenv is activated, display it in grey
 	PROMPT='%(12V.%F{242}%12v%f .)'
 
+	# if PURE_ROOT_HASH is set and we are root then prefix prompt with a red hash '#'
+	if (( ${PURE_ROOT_HASH:0} )) && [[ $UID -eq 0 ]]; then
+		PROMPT+='%F{red}# '
+	fi
+
 	# prompt turns red if the previous command didn't exit with 0
 	PROMPT+='%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '
 }

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,10 @@ Defines the git down arrow symbol. The default value is `⇣`.
 
 Defines the git up arrow symbol. The default value is `⇡`.
 
+### `PURE_ROOT_HASH`
+
+Set `PURE_ROOT_HASH=1` to prefix prompt with a red `#` if we are root.
+
 ## Example
 
 ```sh


### PR DESCRIPTION
I propose we add an optional prefix to the prompt if we are root. I find the extra visibility to be of value when working on remote boxes in production.

The proposed prefix is adding a red `#`.
e.g. `# ❯`

![screenshot](https://user-images.githubusercontent.com/4959702/36287141-069adcdc-1281-11e8-8f1e-3e84b75a2711.png)

We should default to hiding the prefix unless configured to do otherwise. This is accomplished by checking for the existence of the PURE_ROOT_HASH variable, which is by default not set.