### PR TITLE
Add variable for overriding default prompt symbol color

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -465,7 +465,7 @@ prompt_pure_setup() {
 	PROMPT='%(12V.%F{242}%12v%f .)'
 
 	# prompt turns red if the previous command didn't exit with 0
-	PROMPT+='%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '
+	PROMPT+='%(?.%F{${PURE_PROMPT_SYMBOL_COLOR:-magenta}}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '
 }
 
 prompt_pure_setup "$@"

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,10 @@ Time in seconds to delay git dirty checking for large repositories (git status t
 
 Defines the prompt symbol. The default value is `❯`.
 
+### `PURE_PROMPT_SYMBOL_COLOR`
+
+Defines the prompt symbol color. The default value is `magenta`.
+
 ### `PURE_GIT_DOWN_ARROW`
 
 Defines the git down arrow symbol. The default value is `⇣`.


### PR DESCRIPTION
I have added a new variable `PURE_PROMPT_SYMBOL_COLOR` to override the default color `magenta`.

Since it is hard to differentiate between `magenta` and `red` there is a possibility that we might fail to notice when a command exits with a non-zero status.