### PR TITLE
Avoid setting title over serial console

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -53,8 +53,15 @@ prompt_pure_check_cmd_exec_time() {
 }
 
 prompt_pure_set_title() {
+	setopt localoptions noshwordsplit
+
 	# emacs terminal does not support settings the title
 	(( ${+EMACS} )) && return
+
+	case $TTY in
+		# Don't set title over serial console.
+		/dev/ttyS[0-9]*) return;;
+	esac
 
 	# tell the terminal we are setting the title
 	print -n '\e]0;'


### PR DESCRIPTION
This PR skips the terminal title when Pure is running over a serial console on Linux. Typically these escape sequences will not be supported resulting in garbage output.

Here's an example from using minicom to connect to a serial console:

<img width="545" alt="screen shot 2018-04-21 at 13 22 16" src="https://user-images.githubusercontent.com/147409/39083087-1814bd98-4567-11e8-8358-a918eb6a80fb.png">

This PR turns this into:

<img width="275" alt="screen shot 2018-04-21 at 13 25 45" src="https://user-images.githubusercontent.com/147409/39083107-91ffa712-4567-11e8-9f07-6eaddaaa7911.png">

Note: The `â` is not relevant here (fixed by setting e.g. `PURE_PROMPT_SYMBOL='>'`).

I think this is a good default behavior as I don't think anyone will expect title support over serial console. We can add more exceptions in the future as people run into problems.