### PR TITLE
Fix line erasure when terminal output does not end in newline

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -141,18 +141,15 @@ prompt_pure_preprompt_render() {
 	local cleaned_ps1=$PROMPT
 	local -H MATCH MBEGIN MEND
 	if [[ $PROMPT = *$prompt_newline* ]]; then
-		# When the prompt contains newlines, we keep everything before the first
-		# and after the last newline, leaving us with everything except the
-		# preprompt. This is needed because some software prefixes the prompt
-		# (e.g. virtualenv).
-		cleaned_ps1=${PROMPT%%${prompt_newline}*}${PROMPT##*${prompt_newline}}
+		# Remove everything from the prompt until the newline. This
+		# removes the preprompt and only the original PROMPT remains.
+		cleaned_ps1=${PROMPT##*${prompt_newline}}
 	fi
 	unset MATCH MBEGIN MEND
 
 	# Construct the new prompt with a clean preprompt.
 	local -ah ps1
 	ps1=(
-		$prompt_newline           # Initial newline, for spaciousness.
 		${(j. .)preprompt_parts}  # Join parts, space separated.
 		$prompt_newline           # Separate preprompt and prompt.
 		$cleaned_ps1
@@ -164,7 +161,10 @@ prompt_pure_preprompt_render() {
 	local expanded_prompt
 	expanded_prompt="${(S%%)PROMPT}"
 
-	if [[ $1 != precmd ]] && [[ $prompt_pure_last_prompt != $expanded_prompt ]]; then
+	if [[ $1 == precmd ]]; then
+		# Initial newline, for spaciousness.
+		print
+	elif [[ $prompt_pure_last_prompt != $expanded_prompt ]]; then
 		# Redraw the prompt.
 		zle && zle .reset-prompt
 	fi


### PR DESCRIPTION
It seems that adding the initial newline in `$PROMPT` allows ZLE to erase the entile line where the newline began. This is problematic when command output does not end with its own newline. A subsequent terminal resize or prompt update that triggers a prompt redraw will then erase the line.

To fix this, we separate the newline from the prompt by calling print manually during precmd.

Previously, Pure tried to keep any potential prefixes the user might have added to the PROMPT (before preprompt). This fix no longer allows such prefixes as doing so would be hackish, and likely a recipe for other unforseen behavior.

**NOTE:** Because the newline is printed by the Pure precmd hook, it's possible that another precmd hook is run afterwards, and if that hook outputs any text, the newline will appear in the wrong place. A possible solution would be to delay adding the hook or at a later point sort the hooks so that Pure is last.

Fixes #390, #376.