### PR TITLE
Always force BatchMode for the Git SSH command

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -269,7 +269,7 @@ prompt_pure_async_git_fetch() {
 	# set GIT_TERMINAL_PROMPT=0 to disable auth prompting for git fetch (git 2.3+)
 	export GIT_TERMINAL_PROMPT=0
 	# set ssh BachMode to disable all interactive ssh password prompting
-	export GIT_SSH_COMMAND=${GIT_SSH_COMMAND:-"ssh -o BatchMode=yes"}
+	export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-"ssh"} -o BatchMode=yes"
 
 	command git -c gc.auto=0 fetch &>/dev/null || return 99
 


### PR DESCRIPTION
The previous implementation did not disable SSH password prompts when `GIT_SSH_COMMAND` has been set. This allowed the zsh-async worker to "break" due to an interactive program capturing keystrokes, which were actually output from the worker.

Fixes #373.