### PR TITLE
Improve the debug prompt (PS4)

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -533,13 +533,10 @@ prompt_pure_setup() {
 	# prompt turns red if the previous command didn't exit with 0
 	PROMPT+='%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '
 
-	# Store %e (execution depth) for in-place expansion via (S%).
+	# Store prompt expansion symbols for in-place expansion via (%). For
+	# some reason it does not work without storing them in a variable first.
 	typeset -ga prompt_pure_debug_depth
 	prompt_pure_debug_depth=('%e' '%N' '%x')
-
-	# Improve the debug prompt (PS4) with colors to highlight essential
-	# parts, show depth by repeating the +-sign and include the line number
-	# where the code resides (%I).
 
 	# Compare is used to check if %N equals %x. When they differ, the main
 	# prompt is used to allow displaying both file name and function. When
@@ -558,6 +555,9 @@ prompt_pure_setup() {
 	# the `:-` operator is used so that if `compare` becomes an empty
 	# string, it is replaced with `secondary`.
 	local ps4_symbols='${${'${ps4_parts[compare]}':+"'${ps4_parts[main]}'"}:-"'${ps4_parts[secondary]}'"}'
+
+	# Improve the debug prompt (PS4), show depth by repeating the +-sign and
+	# add colors to highlight essential parts like file and function name.
 	PROMPT4="${ps4_parts[depth]} ${ps4_symbols}${ps4_parts[prompt]}"
 }
 


### PR DESCRIPTION
I've long wanted to do something about the debug prompt (PS4) to improve usability / visibility. By default, it's not very easy to do a quick scan of the output.

This PR essentially does three things:
- Add colors, to highlight the current function and de-empasize line numbers
- Add an extra line number (`%I`) which represents the line number in the file where the code resides (by default, only the function line number is shown, making it hard(er) to find the relevant code)
- Repeat the + character to indicate the current execution depth, e.g. when a function calls another, the depth is increased
    - This allows you to quickly see which function invoked which

This is the result (when launched via `zsh -x` or `setopt XTRACE`):

<img width="1227" alt="screen shot 2018-04-27 at 20 40 14" src="https://user-images.githubusercontent.com/147409/39376710-4a20d058-4a5b-11e8-85dd-8fec15bec57d.png">

Original looks like this:

<img width="1162" alt="screen shot 2018-04-27 at 19 40 27" src="https://user-images.githubusercontent.com/147409/39375281-6f828c06-4a56-11e8-979e-e50dc1b7b878.png">