### PR TITLE
Prevent hostname from showing up in local X sessions

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -479,7 +479,8 @@ prompt_pure_async_callback() {
 prompt_pure_state_setup() {
 	setopt localoptions noshwordsplit
 
-	local ssh_connection=$SSH_CONNECTION
+	# Check SSH_CONNECTION and the current state.
+	local ssh_connection=${SSH_CONNECTION:-$prompt_pure_detected_ssh_connection}
 	local username
 	if [[ -z $ssh_connection ]] && (( $+commands[who] )); then
 		# When changing user on a remote system, the $SSH_CONNECTION
@@ -502,6 +503,11 @@ prompt_pure_state_setup() {
 		local -H MATCH MBEGIN MEND
 		if [[ $who_out =~ "\(?($reIPv4|$reIPv6|$reHostname)\)?\$" ]]; then
 			ssh_connection=true
+
+			# Export variable to allow detection propagation inside
+			# shells spawned by this one (e.g. tmux does not always
+			# inherit the same tty, which breaks detection).
+			export prompt_pure_detected_ssh_connection=true
 		fi
 		unset MATCH MBEGIN MEND
 	fi

--- a/pure.zsh
+++ b/pure.zsh
@@ -480,7 +480,7 @@ prompt_pure_state_setup() {
 	setopt localoptions noshwordsplit
 
 	# Check SSH_CONNECTION and the current state.
-	local ssh_connection=${SSH_CONNECTION:-$prompt_pure_detected_ssh_connection}
+	local ssh_connection=${SSH_CONNECTION:-$PROMPT_PURE_SSH_CONNECTION}
 	local username
 	if [[ -z $ssh_connection ]] && (( $+commands[who] )); then
 		# When changing user on a remote system, the $SSH_CONNECTION
@@ -502,12 +502,12 @@ prompt_pure_state_setup() {
 		# not on all systems (e.g. busybox).
 		local -H MATCH MBEGIN MEND
 		if [[ $who_out =~ "\(?($reIPv4|$reIPv6|$reHostname)\)?\$" ]]; then
-			ssh_connection=true
+			ssh_connection=$MATCH
 
 			# Export variable to allow detection propagation inside
 			# shells spawned by this one (e.g. tmux does not always
 			# inherit the same tty, which breaks detection).
-			export prompt_pure_detected_ssh_connection=true
+			export PROMPT_PURE_SSH_CONNECTION=$ssh_connection
 		fi
 		unset MATCH MBEGIN MEND
 	fi

--- a/pure.zsh
+++ b/pure.zsh
@@ -484,7 +484,8 @@ prompt_pure_state_setup() {
 	if [[ -z $ssh_connection ]] && (( $+commands[who] )); then
 		# When changing user on a remote system, the $SSH_CONNECTION
 		# environment variable can be lost, attempt detection via who.
-		if who am i | grep -q '(.*)$' &>/dev/null; then
+		# Ignore local X sessions displayed as (:1).
+		if who am i | grep -v '(:[0-9]*)$' | grep -q '(.*)$' &>/dev/null; then
 			ssh_connection=true
 		fi
 	fi
@@ -496,7 +497,9 @@ prompt_pure_state_setup() {
 	[[ $UID -eq 0 ]] && username='%F{white}%n%f%F{242}@%m%f'
 
 	typeset -gA prompt_pure_state
-	prompt_pure_state=(username "$username")
+	prompt_pure_state=(
+		username "$username"
+	)
 }
 
 prompt_pure_setup() {


### PR DESCRIPTION
This change prevents the hostname from showing up when a terminal is opened inside a local X session (displayed as (:1)).

Fixes a regression introduced in #393.