### PR TITLE
Add support for VI-mode indicator

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -197,6 +197,9 @@ prompt_pure_precmd() {
 		export VIRTUAL_ENV_DISABLE_PROMPT=12
 	fi
 
+	# Make sure VIM prompt is reset.
+	prompt_pure_reset_vim_prompt
+
 	# print the preprompt
 	prompt_pure_preprompt_render "precmd"
 }
@@ -481,6 +484,18 @@ prompt_pure_async_callback() {
 	unset prompt_pure_async_render_requested
 }
 
+prompt_pure_update_vim_prompt() {
+	setopt localoptions noshwordsplit
+	prompt_pure_state[prompt]=${${KEYMAP/vicmd/${PURE_PROMPT_VICMD_SYMBOL:-❮}}/(main|viins)/${PURE_PROMPT_SYMBOL:-❯}}
+	zle && zle .reset-prompt
+}
+
+prompt_pure_reset_vim_prompt() {
+	setopt localoptions noshwordsplit
+	prompt_pure_state[prompt]=${PURE_PROMPT_SYMBOL:-❯}
+	zle && zle .reset-prompt
+}
+
 prompt_pure_state_setup() {
 	setopt localoptions noshwordsplit
 
@@ -526,6 +541,7 @@ prompt_pure_state_setup() {
 	typeset -gA prompt_pure_state
 	prompt_pure_state=(
 		username "$username"
+		prompt	 "${PURE_PROMPT_SYMBOL:-❯}"
 	)
 }
 
@@ -549,6 +565,7 @@ prompt_pure_setup() {
 	zmodload zsh/parameter
 
 	autoload -Uz add-zsh-hook
+	autoload -Uz add-zle-hook-widget
 	autoload -Uz vcs_info
 	autoload -Uz async && async
 
@@ -557,11 +574,18 @@ prompt_pure_setup() {
 
 	prompt_pure_state_setup
 
+	zle -N prompt_pure_update_vim_prompt
+	zle -N prompt_pure_reset_vim_prompt
+	if (( $+functions[add-zle-hook-widget] )); then
+		add-zle-hook-widget zle-line-finish prompt_pure_reset_vim_prompt
+		add-zle-hook-widget zle-keymap-select prompt_pure_update_vim_prompt
+	fi
+
 	# if a virtualenv is activated, display it in grey
 	PROMPT='%(12V.%F{242}%12v%f .)'
 
 	# prompt turns red if the previous command didn't exit with 0
-	PROMPT+='%(?.%F{magenta}.%F{red})${PURE_PROMPT_SYMBOL:-❯}%f '
+	PROMPT+='%(?.%F{magenta}.%F{red})${prompt_pure_state[prompt]}%f '
 
 	# Store prompt expansion symbols for in-place expansion via (%). For
 	# some reason it does not work without storing them in a variable first.

--- a/pure.zsh
+++ b/pure.zsh
@@ -565,9 +565,12 @@ prompt_pure_setup() {
 	zmodload zsh/parameter
 
 	autoload -Uz add-zsh-hook
-	autoload -Uz add-zle-hook-widget
 	autoload -Uz vcs_info
 	autoload -Uz async && async
+
+	# The add-zle-hook-widget function is not guaranteed
+	# to be available, it was added in Zsh 5.3.
+	autoload -Uz +X add-zle-hook-widget 2>/dev/null
 
 	add-zsh-hook precmd prompt_pure_precmd
 	add-zsh-hook preexec prompt_pure_preexec

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ Most prompts are cluttered, ugly and slow. I wanted something visually pleasing 
 - Command execution time will be displayed if it exceeds the set threshold.
 - Username and host only displayed when in an SSH session.
 - Shows the current path in the title and the [current folder & command](screenshot-title-cmd.png) when a process is running.
+- Support VI-mode indication by reverse prompt symbol.
 - Makes an excellent starting point for your own custom prompt.
 
 
@@ -88,6 +89,7 @@ prompt pure
 | **`PURE_GIT_UNTRACKED_DIRTY=0`** | Do not include untracked files in dirtiness check. Mostly useful on large repos (like WebKit). |                |
 | **`PURE_GIT_DELAY_DIRTY_CHECK`** | Time in seconds to delay git dirty checking when `git status` takes > 5 seconds.               | `1800` seconds |
 | **`PURE_PROMPT_SYMBOL`**         | Defines the prompt symbol.                                                                     | `❯`            |
+| **`PURE_PROMPT_VICMD_SYMBOL`**   | Defines the prompt symbol used when the `vicmd` keymap is active (VI-mode).                    | `❮`            |
 | **`PURE_GIT_DOWN_ARROW`**        | Defines the git down arrow symbol.                                                             | `⇣`            |
 | **`PURE_GIT_UP_ARROW`**          | Defines the git up arrow symbol.                                                               | `⇡`            |
 

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Most prompts are cluttered, ugly and slow. I wanted something visually pleasing 
 - Command execution time will be displayed if it exceeds the set threshold.
 - Username and host only displayed when in an SSH session.
 - Shows the current path in the title and the [current folder & command](screenshot-title-cmd.png) when a process is running.
-- Support VI-mode indication by reverse prompt symbol.
+- Support VI-mode indication by reverse prompt symbol (Zsh 5.3+).
 - Makes an excellent starting point for your own custom prompt.
 
 


### PR DESCRIPTION
This PR imitates the Wiki implementation.

When merged, we can remove the VI-mode references from the Wiki.

Related: #308, #208, #184 and #98.

Edit: VI-mode can be activated via `bindkey -v`, hitting Escape should enter `vicmd` mode in a default Zsh configuration.