### PR TITLE
updating fpath-reference link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ That's it. Skip to [Getting started](#getting-started).
   - add it as a submodule, or
   - just download [`pure.zsh`](pure.zsh) and [`async.zsh`](async.zsh)
 
-2. Symlink `pure.zsh` to somewhere in [`$fpath`](http://www.refining-linux.org/archives/46/ZSH-Gem-12-Autoloading-functions/) with the name `prompt_pure_setup`.
+2. Symlink `pure.zsh` to somewhere in [`$fpath`](https://www.refining-linux.org/archives/46-ZSH-Gem-12-Autoloading-functions.html) with the name `prompt_pure_setup`.
 
 3. Symlink `async.zsh` in `$fpath` with the name `async`.
 


### PR DESCRIPTION
The old fpath-reference-link wasn't working. The site changed their URL-scheme. Here's an updated link that works.