### PR TITLE
Include symlinks in the repo to simplify setup process

### DIFF
--- a/async
+++ b/async
@@ -1,0 +1,1 @@
+async.zsh

--- a/prompt_pure_setup
+++ b/prompt_pure_setup
@@ -1,0 +1,1 @@
+pure.zsh

--- a/readme.md
+++ b/readme.md
@@ -34,39 +34,15 @@ $ npm install --global pure-prompt
 
 That's it. Skip to [Getting started](#getting-started).
 
-### Manually
+### Manually (per user)
 
-1. Either…
-  - Clone this repo
-  - add it as a submodule, or
-  - just download [`pure.zsh`](pure.zsh) and [`async.zsh`](async.zsh)
+1. Clone this repo into /some/dir
 
-2. Symlink `pure.zsh` to somewhere in [`$fpath`](https://www.refining-linux.org/archives/46-ZSH-Gem-12-Autoloading-functions.html) with the name `prompt_pure_setup`.
+2. modify .zshrc to include
 
-3. Symlink `async.zsh` in `$fpath` with the name `async`.
-
-#### Example
-
-```console
-$ ln -s "$PWD/pure.zsh" /usr/local/share/zsh/site-functions/prompt_pure_setup
-$ ln -s "$PWD/async.zsh" /usr/local/share/zsh/site-functions/async
 ```
-*Run `echo $fpath` to see possible locations.*
-
-For a user-specific installation (which would not require escalated privileges), simply add a directory to `$fpath` for that user:
-
-```sh
-# .zshenv or .zshrc
-fpath=( "$HOME/.zfunctions" $fpath )
+fpath+=("/some/dir")
 ```
-
-Then install the theme there:
-
-```console
-$ ln -s "$PWD/pure.zsh" "$HOME/.zfunctions/prompt_pure_setup"
-$ ln -s "$PWD/async.zsh" "$HOME/.zfunctions/async"
-```
-
 
 ## Getting started
 

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ $ npm install --global pure-prompt
 
 That's it. Skip to [Getting started](#getting-started).
 
-### Manually (per user)
+### Manually
 
 1. Clone this repo into /some/dir
 


### PR DESCRIPTION
See discussion here: https://github.com/sindresorhus/pure/issues/384

This puts the symlinks `async` and `prompt_pure_setup` right in the repo, which removes the necessity of creating them during install.  It is less transparent, because the user doesn't learn which two files need to be in `fpath` but I think the increase in  simplicity is worth it.