### PR TITLE
Show warning when Oh My Zsh themes are enabled

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -192,6 +192,12 @@ prompt_pure_precmd() {
 
 	# print the preprompt
 	prompt_pure_preprompt_render "precmd"
+
+	if [[ -n $ZSH_THEME ]]; then
+		print "WARNING: Oh My Zsh themes are enabled (ZSH_THEME='${ZSH_THEME}'). Pure might not be working correctly."
+		print "For more information, see: https://github.com/sindresorhus/pure#oh-my-zsh"
+		unset ZSH_THEME  # Only show this warning once.
+	fi
 }
 
 prompt_pure_async_git_aliases() {
@@ -606,6 +612,8 @@ prompt_pure_setup() {
 	# Improve the debug prompt (PS4), show depth by repeating the +-sign and
 	# add colors to highlight essential parts like file and function name.
 	PROMPT4="${ps4_parts[depth]} ${ps4_symbols}${ps4_parts[prompt]}"
+
+	unset ZSH_THEME  # Guard against Oh My Zsh themes overriding Pure.
 }
 
 prompt_pure_setup "$@"


### PR DESCRIPTION
I've been wanting to avoid this kind of code in Pure, but I don't really see any way out. Our users keep running into this 😞.

Hopefully with this, and if https://github.com/robbyrussell/oh-my-zsh/issues/7054 leads to anything, the Pure/OMZ first experience will be greatly improved.

<img width="958" alt="screen shot 2018-08-10 at 17 44 36" src="https://user-images.githubusercontent.com/147409/43964330-46eb38f8-9cc5-11e8-9714-afe736ac6ef7.png">

---

The logic here is that if we unset ZSH_THEME during Pure init, we guard
against this scenario:

```
ZSH_THEME=sometheme
prompt pure
source $ZSH/oh-my-zsh.zsh
```

Also, by unsetting ZSH_THEME we can detect the following scenario:

```
prompt pure
ZSH_THEME=othertheme
source $ZSH/oh-my-zsh.zsh
```

And in this case, we show a warning, because there's no telling what
that OMZ theme might have done (precmd hooks, etc).