### PR TITLE
Do not run zle .reset-prompt when switching vi-mode if keys are queued

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -484,7 +484,9 @@ prompt_pure_reset_prompt_symbol() {
 prompt_pure_update_vim_prompt_widget() {
 	setopt localoptions noshwordsplit
 	prompt_pure_state[prompt]=${${KEYMAP/vicmd/${PURE_PROMPT_VICMD_SYMBOL:-❮}}/(main|viins)/${PURE_PROMPT_SYMBOL:-❯}}
-	zle && zle .reset-prompt
+	if (( $KEYS_QUEUED_COUNT == 0 )) ; then
+		zle && zle .reset-prompt
+	fi
 }
 
 prompt_pure_reset_vim_prompt_widget() {


### PR DESCRIPTION
Hello!

I noticed an issue when using Pure with vi-mode. I haven’t tried this on an absolutely clean Zsh installation, but hopefully this repro works for you:

1. Switch to vi-mode with `$ setopt vi`
2. Run some command, like `$ print bark bark`
3. Enter some text in the buffer
4. As quickly as possible, hit `Esc` followed by `c` `c` (which is the vi command to clear the entire line and enter insert mode)

On my machine, this causes the prompt to be drawn one line above where it should be. This can be repeated to progressively move the prompt to the top of the screen, one line at a time.

While poking around trying to figure out what was happening, I noticed that `prompt_pure_update_vim_prompt_widget` was being invoked twice, once for the mode switch to `vicmd` mode, and again for the mode switch back to `main` (insert) mode. Furthermore, on the first invocation, `$KEYS_QUEUED_COUNT`, which is normally 0, was set to 1. For some reason, if this value is greater than 0, calling `zle .reset-prompt` will cause the prompt to be redrawn in the incorrect position.

My theory is that certain vim actions can be “queued up” in ZLE. When typing `Esc`, ZLE will wait a few moments before triggering the mode switch to `vicmd`. However, if we immediately follow by typing `c` `c`, since the first mode switch has yet to occur, we appear to “queue up” a second mode switch back to mode `main`. ZLE will then execute the `prompt_pure_update_vim_prompt_widget` hook twice in quick succession.

**Solution:**
In `prompt_pure_update_vim_prompt_widget`, don’t call `zle .reset-prompt` if `$KEYS_QUEUED_COUNT` is greater than 0. I’m not sure if this check is also needed in `prompt_pure_reset_vim_prompt_widget`, but my gut feeling is no.

**Background info:**
Running `zsh 5.5.1 (x86_64-apple-darwin17.5.0)` on macOS 10.13.6 (17G65). Issue occurs inside and outside of `tmux` (version 2.7), and in both iTerm2 (Build 3.1.7) and Terminal.app (version 2.8.2 (404)). Both `zsh` and `tmux` are binary builds (bottles) installed via Homebrew.