### PR TITLE
Add conda environment name to precmd

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -180,6 +180,10 @@ prompt_pure_precmd() {
 	# Check if we should display the virtual env, we use a sufficiently high
 	# index of psvar (12) here to avoid collisions with user defined entries.
 	psvar[12]=
+	# Check if a conda environment is active and display it's name
+	if [[ -n $CONDA_DEFAULT_ENV ]]; then
+		psvar[12]="${CONDA_DEFAULT_ENV//[$'\t\r\n']}"
+	fi
 	# When VIRTUAL_ENV_DISABLE_PROMPT is empty, it was unset by the user and
 	# Pure should take back control.
 	if [[ -n $VIRTUAL_ENV ]] && [[ -z $VIRTUAL_ENV_DISABLE_PROMPT || $VIRTUAL_ENV_DISABLE_PROMPT = 12 ]]; then


### PR DESCRIPTION
I've seen this issue discussed in the issues, but it has not found it's way into the code.
Credit goes to @minhoolee and @VincentMatthys .
I added trimming of escape sequences for compatibility with Windows.

Preview:
![image](https://user-images.githubusercontent.com/7465688/47037257-c2dabe00-d17e-11e8-8536-e4a4b4404b15.png)
