### PR TITLE
Fix username color

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -536,8 +536,8 @@ prompt_pure_state_setup() {
 	# show username@host if logged in through SSH
 	[[ -n $ssh_connection ]] && username='%F{242}%n@%m%f'
 
-	# show username@host if root, with username in white
-	[[ $UID -eq 0 ]] && username='%F{white}%n%f%F{242}@%m%f'
+	# show username@host if root, with username in default color
+	[[ $UID -eq 0 ]] && username='%f%n%f%F{242}@%m%f'
 
 	typeset -gA prompt_pure_state
 	prompt_pure_state=(


### PR DESCRIPTION
The white color is not compatible with the Terminal which has a white background. We could use other colors. I think the `reset` is a good choice.