### PR TITLE
Update to zsh-async 1.7.1 and recover from unexpected worker death

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -386,6 +386,10 @@ prompt_pure_async_callback() {
 	local do_render=0
 
 	case $job in
+		\[async])
+			# our worker died unexpectedly
+			typeset -g prompt_pure_async_init=0
+			;;
 		prompt_pure_async_vcs_info)
 			local -A info
 			typeset -gA prompt_pure_vcs_info

--- a/pure.zsh
+++ b/pure.zsh
@@ -391,8 +391,11 @@ prompt_pure_async_callback() {
 
 	case $job in
 		\[async])
-			# our worker died unexpectedly
-			typeset -g prompt_pure_async_init=0
+			# code is 1 for corrupted worker output and 2 for dead worker
+			if [[ $code -eq 2 ]]; then
+				# our worker died unexpectedly
+				typeset -g prompt_pure_async_init=0
+			fi
 			;;
 		prompt_pure_async_vcs_info)
 			local -A info


### PR DESCRIPTION
mafredri/zsh-async#31 fixes a bug which has affected me where in some conditions the worker dies unexpectedly. zsh-async now recovers gracefully from this condition by tearing the worker down and notifying the callback.
This commit updates zsh-async and add some code to handle worker disappearance. The worker will be restarted (if I understand correctly) on next prompt redraw. I tested by waiting for the worker to die and then `cd`ing in another directory and checking that the git information updates correctly.