### PR TITLE
Skip grep fork, use native zsh matching

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -517,7 +517,9 @@ prompt_pure_state_setup() {
 		who_out=$(who -m 2>/dev/null)
 		if (( $? )); then
 			# Who am I not supported, fallback to plain who.
-			who_out=$(who 2>/dev/null | grep ${TTY#/dev/})
+			local -a who_in
+			who_in=( ${(f)"$(who 2>/dev/null)"} )
+			who_out="${(M)who_in:#*[[:space:]]${TTY#/dev/}[[:space:]]*}"
 		fi
 
 		local reIPv6='(([0-9a-fA-F]+:)|:){2,}[0-9a-fA-F]+'  # Simplified, only checks partial pattern.


### PR DESCRIPTION
Method taken from http://zdharma.org/Zsh-100-Commits-Club/Zsh-Native-Scripting-Handbook.html

Just a small optimization, I obsess over this kind of stuff. Thanks for pure btw, I've adapted it quite a bit for my [own purposes.](/xPMo/twodir-zsh-theme)