### PR TITLE
Add Git stash support

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -155,7 +155,7 @@ prompt_pure_preprompt_render() {
 	fi
 	# Git stash symbol.
 	if [[ -n $prompt_pure_vcs_info[stash] ]]; then
-		preprompt_parts+=('%F{cyan}≡%f')
+		preprompt_parts+=('%F{cyan}${PURE_GIT_STASH_SYMBOL:-≡}%f')
 	fi
 
 	# Username and machine, if applicable.

--- a/pure.zsh
+++ b/pure.zsh
@@ -394,14 +394,14 @@ prompt_pure_async_refresh() {
 
 	if [[ -z $prompt_pure_git_fetch_pattern ]]; then
 		# We set the pattern here to avoid redoing the pattern check until the
-		# working three has changed. Pull and fetch are always valid patterns.
+		# working tree has changed. Pull and fetch are always valid patterns.
 		typeset -g prompt_pure_git_fetch_pattern="pull|fetch"
 		async_job "prompt_pure" prompt_pure_async_git_aliases
 	fi
 
 	async_job "prompt_pure" prompt_pure_async_git_arrows
 
-	# Do not preform `git fetch` if it is disabled or in home folder.
+	# Do not perform `git fetch` if it is disabled or in home folder.
 	if (( ${PURE_GIT_PULL:-1} )) && [[ $prompt_pure_vcs_info[top] != $HOME ]]; then
 		# Tell the async worker to do a `git fetch`.
 		async_job "prompt_pure" prompt_pure_async_git_fetch

--- a/pure.zsh
+++ b/pure.zsh
@@ -26,7 +26,7 @@
 
 +vi-git-stash() {
 	local -a stashes
-	stashes=$(git stash list 2>/dev/null | wc -l | tr -d ' ')
+	stashes=$(git stash list 2>/dev/null | wc -l)
 	if [[ $stashes -gt 0 ]]; then
 		hook_com[misc]="stash=${stashes}"
 	fi

--- a/pure.zsh
+++ b/pure.zsh
@@ -271,8 +271,7 @@ prompt_pure_async_vcs_info() {
 	# and stash information via misc (%m).
 	zstyle ':vcs_info:git*' formats '%b' '%R' '%a' '%m'
 	zstyle ':vcs_info:git*' actionformats '%b' '%R' '%a' '%m'
-	zstyle -t ":prompt:pure:git:stash" show
-	if [[ $? == 0 ]]; then
+	if [[ $1 == 0 ]]; then
 		zstyle ':vcs_info:git*+set-message:*' hooks git-stash
 	fi
 
@@ -381,7 +380,8 @@ prompt_pure_async_tasks() {
 	fi
 	unset MATCH MBEGIN MEND
 
-	async_job "prompt_pure" prompt_pure_async_vcs_info
+	zstyle -t ":prompt:pure:git:stash" show
+	async_job "prompt_pure" prompt_pure_async_vcs_info $?
 
 	# Only perform tasks inside a Git working tree.
 	[[ -n $prompt_pure_vcs_info[top] ]] || return

--- a/pure.zsh
+++ b/pure.zsh
@@ -155,7 +155,7 @@ prompt_pure_preprompt_render() {
 	fi
 	# Git stash symbol.
 	if [[ -n $prompt_pure_vcs_info[stash] ]]; then
-		preprompt_parts+=('%F{cyan}${PURE_GIT_STASH_SYMBOL:-≡}%f')
+		preprompt_parts+=('%F{$prompt_pure_colors[git:stash]}${PURE_GIT_STASH_SYMBOL:-≡}%f')
 	fi
 
 	# Username and machine, if applicable.
@@ -699,6 +699,7 @@ prompt_pure_setup() {
 	prompt_pure_colors_default=(
 		execution_time       yellow
 		git:arrow            cyan
+		git:stash            cyan
 		git:branch           242
 		git:branch:cached    red
 		git:action           242

--- a/pure.zsh
+++ b/pure.zsh
@@ -153,7 +153,7 @@ prompt_pure_preprompt_render() {
 	if [[ -n $prompt_pure_git_arrows ]]; then
 		preprompt_parts+=('%F{$prompt_pure_colors[git:arrow]}${prompt_pure_git_arrows}%f')
 	fi
-	# Git stash symbol.
+	# Git stash symbol (if opted in).
 	if [[ -n $prompt_pure_vcs_info[stash] ]]; then
 		preprompt_parts+=('%F{$prompt_pure_colors[git:stash]}${PURE_GIT_STASH_SYMBOL:-≡}%f')
 	fi
@@ -271,7 +271,10 @@ prompt_pure_async_vcs_info() {
 	# and stash information via misc (%m).
 	zstyle ':vcs_info:git*' formats '%b' '%R' '%a' '%m'
 	zstyle ':vcs_info:git*' actionformats '%b' '%R' '%a' '%m'
-	zstyle ':vcs_info:git*+set-message:*' hooks git-stash
+	zstyle -t ":prompt:pure:git:stash" show
+	if [[ $? == 0 ]]; then
+		zstyle ':vcs_info:git*+set-message:*' hooks git-stash
+	fi
 
 	vcs_info
 

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,7 @@ As explained in ZSH's [manual](http://zsh.sourceforge.net/Doc/Release/Zsh-Line-E
 Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fzutil-Module) with a pattern of the form `:prompt:pure:$color_name` and style `color`. The color names, their default, and what part they affect are:
 - `execution_time` (yellow) - The execution time of the last command when exceeding `PURE_CMD_MAX_EXEC_TIME`.
 - `git:arrow` (cyan) - For `PURE_GIT_UP_ARROW` and `PURE_GIT_DOWN_ARROW`.
+- `git:stash` (cyan) - For `PURE_GIT_STASH_SYMBOL`.
 - `git:branch` (242) - The name of the current branch when in a Git repository.
 - `git:branch:cached` (red) - The name of the current branch when the data isn't fresh.
 - `git:action` (242) - The current action in progress (cherry-pick, rebase, etc.) when in a Git repository.
@@ -101,11 +102,12 @@ The following diagram shows where each color is applied on the prompt:
 ┌───────────────────────────────────────────── path
 │          ┌────────────────────────────────── git:branch
 │          │      ┌─────────────────────────── git:action
-|          |      |       ┌─────────────────── git:dirty
+│          │      │       ┌─────────────────── git:dirty
 │          │      │       │ ┌───────────────── git:arrow
-│          │      │       │ │        ┌──────── host
-│          │      │       │ │        │
-~/dev/pure master|rebase-i* ⇡ zaphod@heartofgold 42s
+│          │      │       │ │ ┌─────────────── git:stash
+│          │      │       │ │ │        ┌────── host
+│          │      │       │ │ │        │
+~/dev/pure master|rebase-i* ⇡ ≡ zaphod@heartofgold 42s
 venv ❯                        │                  │
 │    │                        │                  └───── execution_time
 │    │                        └──────────────────────── user

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,7 @@ prompt pure
 | **`PURE_PROMPT_VICMD_SYMBOL`**   | Defines the prompt symbol used when the `vicmd` keymap is active (VI-mode).                    | `❮`            |
 | **`PURE_GIT_DOWN_ARROW`**        | Defines the git down arrow symbol.                                                             | `⇣`            |
 | **`PURE_GIT_UP_ARROW`**          | Defines the git up arrow symbol.                                                               | `⇡`            |
+| **`PURE_GIT_STASH_SYMBOL`**      | Defines the git stash symbol.                                                                  | `≡`            |
 
 
 ## Colors

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,9 @@ prompt pure
 | **`PURE_GIT_UP_ARROW`**          | Defines the git up arrow symbol.                                                               | `⇡`            |
 | **`PURE_GIT_STASH_SYMBOL`**      | Defines the git stash symbol.                                                                  | `≡`            |
 
+Showing git stash status as part of the prompt is not activated by default. To activate this you'll need to opt in via `zstyle`:
+
+`zstyle :prompt:pure:git:stash show yes`
 
 ## Colors
 
@@ -143,6 +146,9 @@ zstyle :prompt:pure:path color white
 
 # change the color for both `prompt:success` and `prompt:error`
 zstyle ':prompt:pure:prompt:*' color cyan
+
+# turn on git stash status
+zstyle :prompt:pure:git:stash show yes
 
 prompt pure
 ```


### PR DESCRIPTION
This is adding support for git stashes. E.g. if there are any stashes show an icon, otherwise not (similar to how git arrows behave). Said icon is configurable via `PURE_GIT_STASH_SYMBOL` environment variable.

It's implemented utilizing `vcs_info`'s `misc` message + hook for tracking information about stashes.

Please take this as a proposal I guess; while #365 is still open, I'm aware of the discussion in #317..


<img width="374" alt="screenshot 2019-02-11 at 09 41 54" src="https://user-images.githubusercontent.com/21918/52559184-e17f5780-2df4-11e9-8642-080faeb65e7b.png">

