### PR TITLE
Allow setting pre-prompt by user ENV var

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -113,9 +113,9 @@ prompt_pure_preprompt_render() {
 
 	# Initialize the preprompt array.
 	local -a preprompt_parts
-
+	local default_prompt_pre='%F{blue}'
 	# Set the path.
-	preprompt_parts+=('%F{blue}%~%f')
+	preprompt_parts+=(${PURE_PROMPT_PRE:-$default_prompt_pre}'%~%f')
 
 	# Add git branch and dirty status info.
 	typeset -gA prompt_pure_vcs_info

--- a/pure.zsh
+++ b/pure.zsh
@@ -115,7 +115,8 @@ prompt_pure_preprompt_render() {
 	local -a preprompt_parts
 	local default_prompt_pre='%F{blue}'
 	# Set the path.
-	preprompt_parts+=(${PURE_PROMPT_PRE:-$default_prompt_pre}'%~%f')
+	reset=${reset:-$(tput sgr0)}
+	preprompt_parts+=(${PURE_PROMPT_PRE:-$default_prompt_pre}'%~%f'"$reset")
 
 	# Add git branch and dirty status info.
 	typeset -gA prompt_pure_vcs_info


### PR DESCRIPTION
This will allow you to add stuff before the start of the prompt and/or
change the color of the path.

For example to change the color of the path the user can do:
PURE_PROMPT_PRE='%F{blue}'

To add a clock before the line and alter the color of the path:
PURE_PROMPT_PRE='%* %F{blue}'

Other things can be done but this gives the user a lot of control to
customize the prompt.

Let me know your thoughts, and if it makes more sense to split the
path color and the PRE into separate variables.