### PR TITLE
Add `prompt_pure_system_report` for reporting issues

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -549,10 +549,55 @@ prompt_pure_state_setup() {
 	[[ $UID -eq 0 ]] && username='%F{white}%n%f%F{242}@%m%f'
 
 	typeset -gA prompt_pure_state
-	prompt_pure_state=(
+	prompt_pure_state[version]="1.8.0"
+	prompt_pure_state+=(
 		username "$username"
 		prompt	 "${PURE_PROMPT_SYMBOL:-❯}"
 	)
+}
+
+prompt_pure_system_report() {
+	setopt localoptions noshwordsplit
+
+	print - "- Zsh: $(zsh --version)"
+	print -n - "- Operating system: "
+	case "$(uname -s)" in
+		Darwin)	print "$(sw_vers -productName) $(sw_vers -productVersion) ($(sw_vers -buildVersion))";;
+		*)	print "$(uname -s) ($(uname -v))";;
+	esac
+	print - "- Terminal program: $TERM_PROGRAM ($TERM_PROGRAM_VERSION)"
+
+	local git_version
+	git_version=($(git --version))  # Remove newlines, if hub is present.
+	print - "- Git: $git_version"
+
+	print - "- Pure state:"
+	for k v in "${(@kv)prompt_pure_state}"; do
+		print - "\t- $k: ${(q)v}"
+	done
+	print - "- Virtualenv: $(typeset -p VIRTUAL_ENV_DISABLE_PROMPT)"
+	print - "- Prompt: $(typeset -p PROMPT)"
+
+	local ohmyzsh=0
+	typeset -la frameworks
+	(( $+ANTIBODY_HOME )) && frameworks+=("Antibody")
+	(( $+ADOTDIR )) && frameworks+=("Antigen")
+	(( $+ANTIGEN_HS_HOME )) && frameworks+=("Antigen-hs")
+	(( $+functions[upgrade_oh_my_zsh] )) && {
+		ohmyzsh=1
+		frameworks+=("Oh My Zsh")
+	}
+	(( $+ZPREZTODIR )) && frameworks+=("Prezto")
+	(( $+ZPLUG_ROOT )) && frameworks+=("Zplug")
+	(( $+ZPLGM )) && frameworks+=("Zplugin")
+
+	(( $#frameworks == 0 )) && frameworks+=("None")
+	print - "- Detected frameworks: ${(j:, :)frameworks}"
+
+	if (( ohmyzsh )); then
+		print - "\t- Oh My Zsh:"
+		print - "\t\t- Plugins: ${(j:, :)plugins}"
+	fi
 }
 
 prompt_pure_setup() {

--- a/pure.zsh
+++ b/pure.zsh
@@ -549,7 +549,7 @@ prompt_pure_state_setup() {
 	[[ $UID -eq 0 ]] && username='%F{white}%n%f%F{242}@%m%f'
 
 	typeset -gA prompt_pure_state
-	prompt_pure_state[version]="1.8.0"
+	prompt_pure_state[version]="1.9.0"
 	prompt_pure_state+=(
 		username "$username"
 		prompt	 "${PURE_PROMPT_SYMBOL:-❯}"

--- a/pure.zsh
+++ b/pure.zsh
@@ -573,10 +573,10 @@ prompt_pure_system_report() {
 
 	print - "- Pure state:"
 	for k v in "${(@kv)prompt_pure_state}"; do
-		print - "\t- $k: ${(q)v}"
+		print - "\t- $k: \`${(q)v}\`"
 	done
-	print - "- Virtualenv: $(typeset -p VIRTUAL_ENV_DISABLE_PROMPT)"
-	print - "- Prompt: $(typeset -p PROMPT)"
+	print - "- Virtualenv: \`$(typeset -p VIRTUAL_ENV_DISABLE_PROMPT)\`"
+	print - "- Prompt: \`$(typeset -p PROMPT)\`"
 
 	local ohmyzsh=0
 	typeset -la frameworks


### PR DESCRIPTION
I created this branch a long time ago as a way with helping users report issues. It was a WIP but I've forgotten what I wanted to include or improve.

Output of running `prompt_pure_system_report`:

- Zsh: zsh 5.7.1 (x86_64-apple-darwin18.2.0)
- Operating system: Mac OS X 10.14.3 (18D109)
- Terminal program: iTerm.app (3.2.8beta1)
- Git: git version 2.21.0
- Pure state:
	- username: `''`
	- prompt: `❯`
	- version: `1.8.0`
- Virtualenv: `export VIRTUAL_ENV_DISABLE_PROMPT=12`
- Prompt: `typeset -g PROMPT='%(12V.%F{242}%12v%f .)%(?.%F{magenta}.%F{red})${prompt_pure_state[prompt]}%f '`
- Detected frameworks: None

Thoughts @sindresorhus? I was thinking running this command could be put in the GitHub issue template, but, I realize it will not be helpful if the user can't get Pure installed (as we see occasionally).

Would need to automate updating of `prompt_pure_state[version]="1.8.0"` during version bump before this can be useful (and possibly detect if running from git and/or if the file is modified?)