### PR TITLE
Add support for configuring colors with zstyle

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -106,8 +106,8 @@ prompt_pure_preexec() {
 # Change the colors if their value are different from the current ones
 prompt_pure_set_colors() {
 	local color_temp
-	for key val in ${(kv)prompt_pure_colors}; do
-		zstyle -t ":prompt:pure:$key" color "$val"
+	for key value in ${(kv)prompt_pure_colors}; do
+		zstyle -t ":prompt:pure:$key" color "$value"
 		case $? in
 			1) # The current style is different from the one from zstyle
 				zstyle -s ":prompt:pure:$key" color color_temp

--- a/pure.zsh
+++ b/pure.zsh
@@ -103,19 +103,34 @@ prompt_pure_preexec() {
 	export VIRTUAL_ENV_DISABLE_PROMPT=${VIRTUAL_ENV_DISABLE_PROMPT:-12}
 }
 
+# Change the colors if their value are different from the current ones
+prompt_pure_set_colors() {
+	local color_temp
+	for key val in ${(kv)prompt_pure_colors}; do
+		zstyle -t ":prompt:pure:$key" color "$val"
+		case $? in
+			1) # current style is diffrent than the one from zstyle
+				zstyle -s ":prompt:pure:$key" color color_temp
+				prompt_pure_colors[$key]=$color_temp ;;
+			2) # no style is defined
+				prompt_pure_colors[$key]=$prompt_pure_colors_default[$key] ;;
+		esac
+	done
+}
+
 prompt_pure_preprompt_render() {
 	setopt localoptions noshwordsplit
 
 	# Set color for git branch/dirty status, change color if dirty checking has
 	# been delayed.
-	local git_color=242
-	[[ -n ${prompt_pure_git_last_dirty_check_timestamp+x} ]] && git_color=red
+	local git_color=$prompt_pure_colors[git:branch]
+	[[ -n ${prompt_pure_git_last_dirty_check_timestamp+x} ]] && git_color=$prompt_pure_colors[git:branch:cached]
 
 	# Initialize the preprompt array.
 	local -a preprompt_parts
 
 	# Set the path.
-	preprompt_parts+=('%F{blue}%~%f')
+	preprompt_parts+=('%F{${prompt_pure_colors[path]}}%~%f')
 
 	# Add git branch and dirty status info.
 	typeset -gA prompt_pure_vcs_info
@@ -124,13 +139,13 @@ prompt_pure_preprompt_render() {
 	fi
 	# Git pull/push arrows.
 	if [[ -n $prompt_pure_git_arrows ]]; then
-		preprompt_parts+=('%F{cyan}${prompt_pure_git_arrows}%f')
+		preprompt_parts+=('%F{$prompt_pure_colors[git:arrow]}${prompt_pure_git_arrows}%f')
 	fi
 
 	# Username and machine, if applicable.
 	[[ -n $prompt_pure_state[username] ]] && preprompt_parts+=('${prompt_pure_state[username]}')
 	# Execution time.
-	[[ -n $prompt_pure_cmd_exec_time ]] && preprompt_parts+=('%F{yellow}${prompt_pure_cmd_exec_time}%f')
+	[[ -n $prompt_pure_cmd_exec_time ]] && preprompt_parts+=('%F{$prompt_pure_colors[exec_time]}${prompt_pure_cmd_exec_time}%f')
 
 	local cleaned_ps1=$PROMPT
 	local -H MATCH MBEGIN MEND
@@ -173,6 +188,9 @@ prompt_pure_precmd() {
 
 	# shows the full path in the title
 	prompt_pure_set_title 'expand-prompt' '%~'
+
+	# Modify the colors if some have changed
+	prompt_pure_set_colors
 
 	# preform async git dirty check and fetch
 	prompt_pure_async_tasks
@@ -509,7 +527,7 @@ prompt_pure_state_setup() {
 
 	# Check SSH_CONNECTION and the current state.
 	local ssh_connection=${SSH_CONNECTION:-$PROMPT_PURE_SSH_CONNECTION}
-	local username
+	local username hostname
 	if [[ -z $ssh_connection ]] && (( $+commands[who] )); then
 		# When changing user on a remote system, the $SSH_CONNECTION
 		# environment variable can be lost, attempt detection via who.
@@ -542,11 +560,12 @@ prompt_pure_state_setup() {
 		unset MATCH MBEGIN MEND
 	fi
 
+	hostname='%F{$prompt_pure_colors[host]}@%m%f'
 	# show username@host if logged in through SSH
-	[[ -n $ssh_connection ]] && username='%F{242}%n@%m%f'
+	[[ -n $ssh_connection ]] && username='%F{$prompt_pure_colors[user]}%n%f'"$hostname"
 
 	# show username@host if root, with username in default color
-	[[ $UID -eq 0 ]] && username='%f%n%f%F{242}@%m%f'
+	[[ $UID -eq 0 ]] && username='%F{$prompt_pure_colors[user:root]}%n%f'"$hostname"
 
 	typeset -gA prompt_pure_state
 	prompt_pure_state[version]="1.9.0"
@@ -618,6 +637,7 @@ prompt_pure_setup() {
 	zmodload zsh/datetime
 	zmodload zsh/zle
 	zmodload zsh/parameter
+	zmodload zsh/zutil
 
 	autoload -Uz add-zsh-hook
 	autoload -Uz vcs_info
@@ -626,6 +646,23 @@ prompt_pure_setup() {
 	# The add-zle-hook-widget function is not guaranteed
 	# to be available, it was added in Zsh 5.3.
 	autoload -Uz +X add-zle-hook-widget 2>/dev/null
+
+	# Set the colors
+	typeset -gA prompt_pure_colors_default prompt_pure_colors
+	prompt_pure_colors_default=(
+		exec_time            yellow
+		git:arrow            cyan
+		git:branch           242
+		git:branch:cached    red
+		host                 242
+		path                 blue
+		prompt:error         red
+		prompt:success       magenta
+		user                 242
+		user:root            default
+		virtualenv           242
+	)
+	prompt_pure_colors=("${(@fkv)prompt_pure_colors_default}")
 
 	add-zsh-hook precmd prompt_pure_precmd
 	add-zsh-hook preexec prompt_pure_preexec
@@ -640,10 +677,10 @@ prompt_pure_setup() {
 	fi
 
 	# if a virtualenv is activated, display it in grey
-	PROMPT='%(12V.%F{242}%12v%f .)'
+	PROMPT='%(12V.%F{$prompt_pure_colors[virtualenv]}%12v%f .)'
 
 	# prompt turns red if the previous command didn't exit with 0
-	PROMPT+='%(?.%F{magenta}.%F{red})${prompt_pure_state[prompt]}%f '
+	PROMPT+='%(?.%F{$prompt_pure_colors[prompt:success]}.%F{$prompt_pure_colors[prompt:error]})${prompt_pure_state[prompt]}%f '
 
 	# Store prompt expansion symbols for in-place expansion via (%). For
 	# some reason it does not work without storing them in a variable first.

--- a/pure.zsh
+++ b/pure.zsh
@@ -109,10 +109,10 @@ prompt_pure_set_colors() {
 	for key val in ${(kv)prompt_pure_colors}; do
 		zstyle -t ":prompt:pure:$key" color "$val"
 		case $? in
-			1) # current style is diffrent than the one from zstyle
+			1) # The current style is different from the one from zstyle
 				zstyle -s ":prompt:pure:$key" color color_temp
 				prompt_pure_colors[$key]=$color_temp ;;
-			2) # no style is defined
+			2) # No style is defined
 				prompt_pure_colors[$key]=$prompt_pure_colors_default[$key] ;;
 		esac
 	done

--- a/pure.zsh
+++ b/pure.zsh
@@ -145,7 +145,7 @@ prompt_pure_preprompt_render() {
 	# Username and machine, if applicable.
 	[[ -n $prompt_pure_state[username] ]] && preprompt_parts+=('${prompt_pure_state[username]}')
 	# Execution time.
-	[[ -n $prompt_pure_cmd_exec_time ]] && preprompt_parts+=('%F{$prompt_pure_colors[exec_time]}${prompt_pure_cmd_exec_time}%f')
+	[[ -n $prompt_pure_cmd_exec_time ]] && preprompt_parts+=('%F{$prompt_pure_colors[execution_time]}${prompt_pure_cmd_exec_time}%f')
 
 	local cleaned_ps1=$PROMPT
 	local -H MATCH MBEGIN MEND
@@ -650,7 +650,7 @@ prompt_pure_setup() {
 	# Set the colors
 	typeset -gA prompt_pure_colors_default prompt_pure_colors
 	prompt_pure_colors_default=(
-		exec_time            yellow
+		execution_time       yellow
 		git:arrow            cyan
 		git:branch           242
 		git:branch:cached    red

--- a/readme.md
+++ b/readme.md
@@ -93,23 +93,25 @@ prompt pure
 | **`PURE_GIT_DOWN_ARROW`**        | Defines the git down arrow symbol.                                                             | `⇣`            |
 | **`PURE_GIT_UP_ARROW`**          | Defines the git up arrow symbol.                                                               | `⇡`            |
 
+
 ## Colors
 
-Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fzutil-Module) with a pattern of the form `:prompt:pure:$color_name` and style `color`. The color names, their default and what part they affect are:
-- `exec_time` (yellow), the execution time of the last command when exceeding `PURE_CMD_MAX_EXEC_TIME`
-- `git:arrow` (cyan), for `PURE_GIT_UP_ARROW` and `PURE_GIT_DOWN_ARROW`
-- `git:branch` (242), the name of the current branch when in a git repository
-- `git:branch:cached` (red), the name of the current branch when the data isn't fresh
-- `host` (242), the hostname when on a remote machine
-- `path` (blue), the current path ie. `PWD`
-- `prompt:error` (red), the `PURE_PROMPT_SYMBOL` when the previous command has *failed*
-- `prompt:success` (magenta), the `PURE_PROMPT_SYMBOL` when the previous command has *succeded*
-- `user` (242), the username when on remote machine
-- `user:root` (default), the username when the user is root
-- `virtualenv` (242), the name of the python virtualenv when in use
+Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fzutil-Module) with a pattern of the form `:prompt:pure:$color_name` and style `color`. The color names, their default, and what part they affect are:
+- `exec_time` (yellow) - The execution time of the last command when exceeding `PURE_CMD_MAX_EXEC_TIME`
+- `git:arrow` (cyan) - For `PURE_GIT_UP_ARROW` and `PURE_GIT_DOWN_ARROW`
+- `git:branch` (242) - The name of the current branch when in a Git repository
+- `git:branch:cached` (red) - The name of the current branch when the data isn't fresh
+- `host` (242) - The hostname when on a remote machine
+- `path` (blue) - The current path, for example, `PWD`
+- `prompt:error` (red) - The `PURE_PROMPT_SYMBOL` when the previous command has *failed*
+- `prompt:success` (magenta) - The `PURE_PROMPT_SYMBOL` when the previous command has *succeded*
+- `user` (242) - The username when on remote machine
+- `user:root` (default) - The username when the user is root
+- `virtualenv` (242) - The name of the Python `virtualenv` when in use
 
-The following diagram shows where each colors are applied on the prompt.
-``` text
+The following diagram shows where each color is applied on the prompt:
+
+```
 path
 |          git:branch
 |          |       git:arrow
@@ -122,6 +124,7 @@ venv ❯               |                   |
 |    prompt
 virtualenv
 ```
+
 
 ## Example
 

--- a/readme.md
+++ b/readme.md
@@ -98,21 +98,21 @@ prompt pure
 
 As explained in ZSH's [manual](http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting), color values can be:
 - A decimal integer corresponding to the color index of your terminal. If your `$TERM` is `xterm-256color`, see this [chart](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg).
-- The name of one of the following nine colours: `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, and `default` (the terminal’s default foreground)
-- `#` followed by an RGB triplet in hexadecimal format, for example `#424242`. *Only* if your terminal support 24-bit colors (true color) or when the module [`zsh/nearcolor`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fnearcolor-Module) is loaded.
+- The name of one of the following nine colors: `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, and `default` (the terminal’s default foreground)
+- `#` followed by an RGB triplet in hexadecimal format, for example `#424242`. Only if your terminal supports 24-bit colors (true color) or when the [`zsh/nearcolor` module](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fnearcolor-Module) is loaded.
 
 Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fzutil-Module) with a pattern of the form `:prompt:pure:$color_name` and style `color`. The color names, their default, and what part they affect are:
-- `exec_time` (yellow) - The execution time of the last command when exceeding `PURE_CMD_MAX_EXEC_TIME`
-- `git:arrow` (cyan) - For `PURE_GIT_UP_ARROW` and `PURE_GIT_DOWN_ARROW`
-- `git:branch` (242) - The name of the current branch when in a Git repository
-- `git:branch:cached` (red) - The name of the current branch when the data isn't fresh
-- `host` (242) - The hostname when on a remote machine
-- `path` (blue) - The current path, for example, `PWD`
-- `prompt:error` (red) - The `PURE_PROMPT_SYMBOL` when the previous command has *failed*
-- `prompt:success` (magenta) - The `PURE_PROMPT_SYMBOL` when the previous command has *succeded*
-- `user` (242) - The username when on remote machine
-- `user:root` (default) - The username when the user is root
-- `virtualenv` (242) - The name of the Python `virtualenv` when in use
+- `exec_time` (yellow) - The execution time of the last command when exceeding `PURE_CMD_MAX_EXEC_TIME`.
+- `git:arrow` (cyan) - For `PURE_GIT_UP_ARROW` and `PURE_GIT_DOWN_ARROW`.
+- `git:branch` (242) - The name of the current branch when in a Git repository.
+- `git:branch:cached` (red) - The name of the current branch when the data isn't fresh.
+- `host` (242) - The hostname when on a remote machine.
+- `path` (blue) - The current path, for example, `PWD`.
+- `prompt:error` (red) - The `PURE_PROMPT_SYMBOL` when the previous command has *failed*.
+- `prompt:success` (magenta) - The `PURE_PROMPT_SYMBOL` when the previous command has *succeded*.
+- `user` (242) - The username when on remote machine.
+- `user:root` (default) - The username when the user is root.
+- `virtualenv` (242) - The name of the Python `virtualenv` when in use.
 
 The following diagram shows where each color is applied on the prompt:
 
@@ -132,15 +132,16 @@ virtualenv
 
 ### RGB colors
 
-There are two ways to use RGB colors with the hexadecimal format. The correct way is to use a [terminal that support 24-bit colors](https://gist.github.com/XVilka/8346728) and enable this feature as explained in its documentation.
+There are two ways to use RGB colors with the hexadecimal format. The correct way is to use a [terminal that support 24-bit colors](https://gist.github.com/XVilka/8346728) and enable this feature as explained in the terminal's documentation.
 
-If you can't use such terminal, the module [`zsh/nearcolor`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fnearcolor-Module) can be useful. It will map any hexadecimal color to the nearest color in the 88 or 256 color palettes of your termial, but without using the first 16 colors, since their values can be modifed by the user. Keep in mind that when using this module you won't be able to display true RGB colors. It only allows you to specify colors in a more convenient way. Following is an example on how to use this module:
+If you can't use such terminal, the module [`zsh/nearcolor`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fnearcolor-Module) can be useful. It will map any hexadecimal color to the nearest color in the 88 or 256 color palettes of your termial, but without using the first 16 colors, since their values can be modified by the user. Keep in mind that when using this module you won't be able to display true RGB colors. It only allows you to specify colors in a more convenient way. The following is an example on how to use this module:
 
 ```sh
 # .zshrc
 zmodload zsh/nearcolor
 zstyle :prompt:pure:path color '#FF0000'
 ```
+
 
 ## Example
 

--- a/readme.md
+++ b/readme.md
@@ -132,9 +132,11 @@ autoload -U promptinit; promptinit
 
 # optionally define some options
 PURE_CMD_MAX_EXEC_TIME=10
-# change path color
+
+# change the path color
 zstyle :prompt:pure:path color white
-# set the prompt color whatever the result of the last command
+
+# set the color for both `prompt:success` and `prompt:error`
 zstyle ':prompt:pure:prompt:*' color green
 
 prompt pure

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,11 @@ prompt pure
 
 ## Colors
 
+As explained in ZSH's[manual](http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting) color values can be:
+- a decimal integer corresponding to the color index of your terminal, if your `$TERM` is `xterm-256color` see this [chart](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg)
+- the name of one of the following nine colours: `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white` and `default` (the terminal’s default foreground)
+- ‘#’ followed by an RGB triplet in hexadecimal format (ex. `#424242`), *only* if your terminal support 24bit colors or when the module [`zsh/nearcolor`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fnearcolor-Module) is loaded
+
 Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fzutil-Module) with a pattern of the form `:prompt:pure:$color_name` and style `color`. The color names, their default, and what part they affect are:
 - `exec_time` (yellow) - The execution time of the last command when exceeding `PURE_CMD_MAX_EXEC_TIME`
 - `git:arrow` (cyan) - For `PURE_GIT_UP_ARROW` and `PURE_GIT_DOWN_ARROW`
@@ -125,6 +130,15 @@ venv ❯               |                   |
 virtualenv
 ```
 
+### RGB colors
+
+There is two way to use RGB colors with the hexadecimal format. The correct way is to use a terminal that support 24bit colors and enable this feature as explained in it's documentation.
+If you can't use such terminal the module [`zsh/nearcolor`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fnearcolor-Module) is here for you, it will map any hexadecimal color to the nearest color in the 88 or 256 color palettes of your termial but without using the first 16 colors since their values can be modifed by the user. Understand that when using this module you won't be able to display true RGB colors, it only allows you to specify colors in a more convenient way. Following is an example on how to use this module:
+```sh
+# .zshrc
+zmodload zsh/nearcolor
+zstyle :prompt:pure:path color '#FF0000'
+```
 
 ## Example
 

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,36 @@ prompt pure
 | **`PURE_GIT_DOWN_ARROW`**        | Defines the git down arrow symbol.                                                             | `⇣`            |
 | **`PURE_GIT_UP_ARROW`**          | Defines the git up arrow symbol.                                                               | `⇡`            |
 
+## Colors
+
+Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fzutil-Module) with a pattern of the form `:prompt:pure:$color_name` and style `color`. The color names, their default and what part they affect are:
+- `exec_time` (yellow), the execution time of the last command when exceeding `PURE_CMD_MAX_EXEC_TIME`
+- `git:arrow` (cyan), for `PURE_GIT_UP_ARROW` and `PURE_GIT_DOWN_ARROW`
+- `git:branch` (242), the name of the current branch when in a git repository
+- `git:branch:cached` (red), the name of the current branch when the data isn't fresh
+- `host` (242), the hostname when on a remote machine
+- `path` (blue), the current path ie. `PWD`
+- `prompt:error` (red), the `PURE_PROMPT_SYMBOL` when the previous command has *failed*
+- `prompt:success` (magenta), the `PURE_PROMPT_SYMBOL` when the previous command has *succeded*
+- `user` (242), the username when on remote machine
+- `user:root` (default), the username when the user is root
+- `virtualenv` (242), the name of the python virtualenv when in use
+
+The following diagram shows where each colors are applied on the prompt.
+``` text
+path
+|          git:branch
+|          |       git:arrow
+|          |       |        host
+|          |       |        |
+~/dev/pure master* ⇡ zaphod@heartofgold  42s
+venv ❯               |                   |
+|    |               |                   exec_time
+|    |               user
+|    prompt
+virtualenv
+```
+
 ## Example
 
 ```sh
@@ -102,6 +132,10 @@ autoload -U promptinit; promptinit
 
 # optionally define some options
 PURE_CMD_MAX_EXEC_TIME=10
+# change path color
+zstyle :prompt:pure:path color white
+# set the prompt color whatever the result of the last command
+zstyle ':prompt:pure:prompt:*' color green
 
 prompt pure
 ```

--- a/readme.md
+++ b/readme.md
@@ -139,8 +139,8 @@ PURE_CMD_MAX_EXEC_TIME=10
 # change the path color
 zstyle :prompt:pure:path color white
 
-# set the color for both `prompt:success` and `prompt:error`
-zstyle ':prompt:pure:prompt:*' color green
+# change the color for both `prompt:success` and `prompt:error`
+zstyle ':prompt:pure:prompt:*' color cyan
 
 prompt pure
 ```

--- a/readme.md
+++ b/readme.md
@@ -96,10 +96,10 @@ prompt pure
 
 ## Colors
 
-As explained in ZSH's[manual](http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting) color values can be:
-- a decimal integer corresponding to the color index of your terminal, if your `$TERM` is `xterm-256color` see this [chart](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg)
-- the name of one of the following nine colours: `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white` and `default` (the terminal’s default foreground)
-- ‘#’ followed by an RGB triplet in hexadecimal format (ex. `#424242`), *only* if your terminal support 24bit colors or when the module [`zsh/nearcolor`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fnearcolor-Module) is loaded
+As explained in ZSH's [manual](http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting), color values can be:
+- A decimal integer corresponding to the color index of your terminal. If your `$TERM` is `xterm-256color`, see this [chart](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg).
+- The name of one of the following nine colours: `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, and `default` (the terminal’s default foreground)
+- `#` followed by an RGB triplet in hexadecimal format, for example `#424242`. *Only* if your terminal support 24-bit colors (true color) or when the module [`zsh/nearcolor`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fnearcolor-Module) is loaded.
 
 Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fzutil-Module) with a pattern of the form `:prompt:pure:$color_name` and style `color`. The color names, their default, and what part they affect are:
 - `exec_time` (yellow) - The execution time of the last command when exceeding `PURE_CMD_MAX_EXEC_TIME`
@@ -132,8 +132,10 @@ virtualenv
 
 ### RGB colors
 
-There is two way to use RGB colors with the hexadecimal format. The correct way is to use a terminal that support 24bit colors and enable this feature as explained in it's documentation.
-If you can't use such terminal the module [`zsh/nearcolor`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fnearcolor-Module) is here for you, it will map any hexadecimal color to the nearest color in the 88 or 256 color palettes of your termial but without using the first 16 colors since their values can be modifed by the user. Understand that when using this module you won't be able to display true RGB colors, it only allows you to specify colors in a more convenient way. Following is an example on how to use this module:
+There are two ways to use RGB colors with the hexadecimal format. The correct way is to use a [terminal that support 24-bit colors](https://gist.github.com/XVilka/8346728) and enable this feature as explained in its documentation.
+
+If you can't use such terminal, the module [`zsh/nearcolor`](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fnearcolor-Module) can be useful. It will map any hexadecimal color to the nearest color in the 88 or 256 color palettes of your termial, but without using the first 16 colors, since their values can be modifed by the user. Keep in mind that when using this module you won't be able to display true RGB colors. It only allows you to specify colors in a more convenient way. Following is an example on how to use this module:
+
 ```sh
 # .zshrc
 zmodload zsh/nearcolor


### PR DESCRIPTION
Following the discussion at #306 this PR add the capacity to change the colors of `pure` by using `zstyle` to avoid polluting the global name space.

Available colors:
- branch
- error
- exec_time
- git_arrow
- host
- path
- root
- success
- user
- virtualenv

Fixes #126
Fixes #303 
Fixes #306 
Fixes #389 
Closes #256 
Closes #450

EDIT: Add requested colors.