### PR TITLE
Avoid performing prompt reset in zle-line-finish hook

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -517,7 +517,8 @@ prompt_pure_reset_vim_prompt_widget() {
 	setopt localoptions noshwordsplit
 	prompt_pure_reset_prompt_symbol
 
-	prompt_pure_reset_prompt
+	# We can't perform a prompt reset at this point because it
+	# removes the prompt marks inserted by macOS Terminal.
 }
 
 prompt_pure_state_setup() {


### PR DESCRIPTION
We can't perform a prompt reset at this point because it removes the prompt marks inserted by macOS Terminal.

This change will no longer allow the prompt to reset (from ❮ to ❯) when the user hits [Enter] in VI-mode. However, this might actually be the right thing to do.

Fixes #476.