### PR TITLE
Suppress warning of WARN_CREATE_GLOBAL option

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -105,7 +105,7 @@ prompt_pure_preexec() {
 
 # Change the colors if their value are different from the current ones.
 prompt_pure_set_colors() {
-	local color_temp
+	local color_temp key value
 	for key value in ${(kv)prompt_pure_colors}; do
 		zstyle -t ":prompt:pure:$key" color "$value"
 		case $? in


### PR DESCRIPTION
Similar issue with https://github.com/sindresorhus/pure/issues/345.

To produce this issue, enter `setopt WARN_CREATE_GLOBAL` once in your `.zshrc` and see the following warning before prompt.

```
prompt_pure_set_colors:2: scalar parameter key created globally in function prompt_pure_set_colors
prompt_pure_set_colors:2: scalar parameter value created globally in function prompt_pure_set_colors
```