### PR TITLE
Add zstyle color support to PS2

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -689,6 +689,7 @@ prompt_pure_setup() {
 		path                 blue
 		prompt:error         red
 		prompt:success       magenta
+		prompt2:faded        242
 		user                 242
 		user:root            default
 		virtualenv           242
@@ -712,10 +713,11 @@ prompt_pure_setup() {
 	PROMPT='%(12V.%F{$prompt_pure_colors[virtualenv]}%12v%f .)'
 
 	# Prompt turns red if the previous command didn't exit with 0.
-	PROMPT+='%(?.%F{$prompt_pure_colors[prompt:success]}.%F{$prompt_pure_colors[prompt:error]})${prompt_pure_state[prompt]}%f '
+	local prompt_indicator='%(?.%F{$prompt_pure_colors[prompt:success]}.%F{$prompt_pure_colors[prompt:error]})${prompt_pure_state[prompt]}%f '
+	PROMPT+=$prompt_indicator
 
 	# Indicate continuation prompt by … and use a darker color for it.
-	PROMPT2='%F{242}%_… %f%(?.%F{magenta}.%F{red})${prompt_pure_state[prompt]}%f '
+	PROMPT2='%F{$prompt_pure_colors[prompt2:faded]}… %(1_.%_ .%_)%f'$prompt_indicator
 
 	# Store prompt expansion symbols for in-place expansion via (%). For
 	# some reason it does not work without storing them in a variable first.

--- a/pure.zsh
+++ b/pure.zsh
@@ -689,7 +689,7 @@ prompt_pure_setup() {
 		path                 blue
 		prompt:error         red
 		prompt:success       magenta
-		prompt2:faded        242
+		prompt:continuation  242
 		user                 242
 		user:root            default
 		virtualenv           242
@@ -717,7 +717,7 @@ prompt_pure_setup() {
 	PROMPT+=$prompt_indicator
 
 	# Indicate continuation prompt by … and use a darker color for it.
-	PROMPT2='%F{$prompt_pure_colors[prompt2:faded]}… %(1_.%_ .%_)%f'$prompt_indicator
+	PROMPT2='%F{$prompt_pure_colors[prompt:continuation]}… %(1_.%_ .%_)%f'$prompt_indicator
 
 	# Store prompt expansion symbols for in-place expansion via (%). For
 	# some reason it does not work without storing them in a variable first.

--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release
 - `path` (blue) - The current path, for example, `PWD`.
 - `prompt:error` (red) - The `PURE_PROMPT_SYMBOL` when the previous command has *failed*.
 - `prompt:success` (magenta) - The `PURE_PROMPT_SYMBOL` when the previous command has *succeded*.
-- `prompt2:faded` (242) - The color for showing the state of the parser in the continuation prompt (PS2).
+- `prompt:continuation` (242) - The color for showing the state of the parser in the continuation prompt (PS2). It's the pink part in [this screenshot](https://user-images.githubusercontent.com/147409/70068574-ebc74800-15f8-11ea-84c0-8b94a4b57ff4.png), it appears in the same spot as `virtualenv`. You could for example matching both colors so that Pure has a uniform look.
 - `user` (242) - The username when on remote machine.
 - `user:root` (default) - The username when the user is root.
 - `virtualenv` (242) - The name of the Python `virtualenv` when in use.
@@ -110,7 +110,7 @@ venv ❯                        │                  │
 │    │                        │                  └───── execution_time
 │    │                        └──────────────────────── user
 │    └───────────────────────────────────────────────── prompt
-└────────────────────────────────────────────────────── virtualenv
+└────────────────────────────────────────────────────── virtualenv (or prompt:continuation)
 ```
 
 ### RGB colors

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,7 @@ Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release
 - `path` (blue) - The current path, for example, `PWD`.
 - `prompt:error` (red) - The `PURE_PROMPT_SYMBOL` when the previous command has *failed*.
 - `prompt:success` (magenta) - The `PURE_PROMPT_SYMBOL` when the previous command has *succeded*.
+- `prompt2:faded` (242) - The color for showing the state of the parser in the continuation prompt (PS2).
 - `user` (242) - The username when on remote machine.
 - `user:root` (default) - The username when the user is root.
 - `virtualenv` (242) - The name of the Python `virtualenv` when in use.


### PR DESCRIPTION
The most important part of this PR changes the PS2 prompt to use the actual `prompt:success` / `prompt:error` colors. The second part adds support for styling the PS2 part that prefixes the prompt indicator (e.g. `... quote`).

Not sure what to call it, went with `prompt2:faded` as it's the faded part of the PS2, but it might as well be called `prompt2:parser_status`.