### PR TITLE
Support changing color of the Git action part of the prompt

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -134,7 +134,11 @@ prompt_pure_preprompt_render() {
 	# Add Git branch and dirty status info.
 	typeset -gA prompt_pure_vcs_info
 	if [[ -n $prompt_pure_vcs_info[branch] ]]; then
-		preprompt_parts+=("%F{$git_color}"'${prompt_pure_vcs_info[branch]}${prompt_pure_git_dirty}%f')
+		local branch="%F{$git_color}"'${prompt_pure_vcs_info[branch]}'
+		if [[ -n $prompt_pure_vcs_info[action] ]]; then
+			branch+="|%F{$prompt_pure_colors[git:action]}"'$prompt_pure_vcs_info[action]'"%F{$git_color}"
+		fi
+		preprompt_parts+=("$branch"'${prompt_pure_git_dirty}%f')
 	fi
 	# Git pull/push arrows.
 	if [[ -n $prompt_pure_git_arrows ]]; then
@@ -248,11 +252,11 @@ prompt_pure_async_vcs_info() {
 	# to be used or configured as the user pleases.
 	zstyle ':vcs_info:*' enable git
 	zstyle ':vcs_info:*' use-simple true
-	# Only export two message variables from `vcs_info`.
-	zstyle ':vcs_info:*' max-exports 2
-	# Export branch (%b) and Git toplevel (%R).
+	# Only export three message variables from `vcs_info`.
+	zstyle ':vcs_info:*' max-exports 3
+	# Export branch (%b), Git toplevel (%R), and action (rebase/cherry-pick) (%a).
 	zstyle ':vcs_info:git*' formats '%b' '%R'
-	zstyle ':vcs_info:git*' actionformats '%b|%a' '%R'
+	zstyle ':vcs_info:git*' actionformats '%b' '%R' '%a'
 
 	vcs_info
 
@@ -260,6 +264,7 @@ prompt_pure_async_vcs_info() {
 	info[pwd]=$PWD
 	info[top]=$vcs_info_msg_1_
 	info[branch]=$vcs_info_msg_0_
+	info[action]=$vcs_info_msg_2_
 
 	print -r - ${(@kvq)info}
 }
@@ -446,6 +451,7 @@ prompt_pure_async_callback() {
 			# Always update branch and top-level.
 			prompt_pure_vcs_info[branch]=$info[branch]
 			prompt_pure_vcs_info[top]=$info[top]
+			prompt_pure_vcs_info[action]=$info[action]
 
 			do_render=1
 			;;
@@ -672,6 +678,7 @@ prompt_pure_setup() {
 		git:arrow            cyan
 		git:branch           242
 		git:branch:cached    red
+		git:action           242
 		host                 242
 		path                 blue
 		prompt:error         red

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,7 @@ Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release
 - `git:arrow` (cyan) - For `PURE_GIT_UP_ARROW` and `PURE_GIT_DOWN_ARROW`.
 - `git:branch` (242) - The name of the current branch when in a Git repository.
 - `git:branch:cached` (red) - The name of the current branch when the data isn't fresh.
+- `git:action` (242) - The current action in progress (cherry-pick, rebase, etc.) when in a Git repository.
 - `host` (242) - The hostname when on a remote machine.
 - `path` (blue) - The current path, for example, `PWD`.
 - `prompt:error` (red) - The `PURE_PROMPT_SYMBOL` when the previous command has *failed*.
@@ -97,15 +98,15 @@ The following diagram shows where each color is applied on the prompt:
 ```
 ┌───────────────────────────────────────────── path
 │          ┌────────────────────────────────── git:branch
-│          │       ┌────────────────────────── git:arrow
-│          │       │        ┌───────────────── host
-│          │       │        │
-~/dev/pure master* ⇡ zaphod@heartofgold 42s
-venv ❯               │                  │
-│    │               │                  └───── execution_time
-│    │               └──────────────────────── user
-│    └──────────────────────────────────────── prompt
-└───────────────────────────────────────────── virtualenv
+│          │      ┌─────────────────────────── git:action
+│          │      │         ┌───────────────── host
+│          │      │         │
+~/dev/pure master|rebase-i* ⇡ zaphod@heartofgold 42s
+venv ❯                        │                  │
+│    │                        │                  └───── execution_time
+│    │                        └──────────────────────── user
+│    └───────────────────────────────────────────────── prompt
+└────────────────────────────────────────────────────── virtualenv
 ```
 
 ### RGB colors

--- a/readme.md
+++ b/readme.md
@@ -99,8 +99,9 @@ The following diagram shows where each color is applied on the prompt:
 ┌───────────────────────────────────────────── path
 │          ┌────────────────────────────────── git:branch
 │          │      ┌─────────────────────────── git:action
-│          │      │         ┌───────────────── host
-│          │      │         │
+│          │      │         ┌───────────────── git:arrow
+│          │      │         │        ┌──────── host
+│          │      │         │        │
 ~/dev/pure master|rebase-i* ⇡ zaphod@heartofgold 42s
 venv ❯                        │                  │
 │    │                        │                  └───── execution_time


### PR DESCRIPTION
I do a lot of rebasing and cherry-picking and I like to know when I'm in that mode, so I added an option to make it stand out more.

A picture is worth a thousand words:

![Screenshot 2019-07-17 at 11 03 54](https://user-images.githubusercontent.com/34150/61366997-a4772f80-a882-11e9-9335-8155415e65ff.png)
