### PR TITLE
Add coloring for git dirty-asterisk

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -123,6 +123,7 @@ prompt_pure_preprompt_render() {
 
 	# Set color for Git branch/dirty status and change color if dirty checking has been delayed.
 	local git_color=$prompt_pure_colors[git:branch]
+	local git_dirty_color=$prompt_pure_colors[git:branch:dirty]
 	[[ -n ${prompt_pure_git_last_dirty_check_timestamp+x} ]] && git_color=$prompt_pure_colors[git:branch:cached]
 
 	# Initialize the preprompt array.
@@ -138,7 +139,7 @@ prompt_pure_preprompt_render() {
 		if [[ -n $prompt_pure_vcs_info[action] ]]; then
 			branch+="|%F{$prompt_pure_colors[git:action]}"'$prompt_pure_vcs_info[action]'"%F{$git_color}"
 		fi
-		preprompt_parts+=("$branch"'${prompt_pure_git_dirty}%f')
+		preprompt_parts+=("$branch""%F{$git_dirty_color}"'${prompt_pure_git_dirty}%f')
 	fi
 	# Git pull/push arrows.
 	if [[ -n $prompt_pure_git_arrows ]]; then
@@ -679,6 +680,7 @@ prompt_pure_setup() {
 		git:branch           242
 		git:branch:cached    red
 		git:action           242
+		git:branch:dirty     218
 		host                 242
 		path                 blue
 		prompt:error         red

--- a/pure.zsh
+++ b/pure.zsh
@@ -123,7 +123,7 @@ prompt_pure_preprompt_render() {
 
 	# Set color for Git branch/dirty status and change color if dirty checking has been delayed.
 	local git_color=$prompt_pure_colors[git:branch]
-	local git_dirty_color=$prompt_pure_colors[git:branch:dirty]
+	local git_dirty_color=$prompt_pure_colors[git:dirty]
 	[[ -n ${prompt_pure_git_last_dirty_check_timestamp+x} ]] && git_color=$prompt_pure_colors[git:branch:cached]
 
 	# Initialize the preprompt array.
@@ -680,7 +680,7 @@ prompt_pure_setup() {
 		git:branch           242
 		git:branch:cached    red
 		git:action           242
-		git:branch:dirty     218
+		git:dirty     		 218
 		host                 242
 		path                 blue
 		prompt:error         red

--- a/pure.zsh
+++ b/pure.zsh
@@ -680,7 +680,7 @@ prompt_pure_setup() {
 		git:branch           242
 		git:branch:cached    red
 		git:action           242
-		git:dirty     		 218
+		git:dirty            218
 		host                 242
 		path                 blue
 		prompt:error         red

--- a/readme.md
+++ b/readme.md
@@ -100,9 +100,10 @@ The following diagram shows where each color is applied on the prompt:
 ┌───────────────────────────────────────────── path
 │          ┌────────────────────────────────── git:branch
 │          │      ┌─────────────────────────── git:action
-│          │      │         ┌───────────────── git:arrow
-│          │      │         │        ┌──────── host
-│          │      │         │        │
+|          |      |       ┌─────────────────── git:dirty
+│          │      │       │ ┌───────────────── git:arrow
+│          │      │       │ │        ┌──────── host
+│          │      │       │ │        │
 ~/dev/pure master|rebase-i* ⇡ zaphod@heartofgold 42s
 venv ❯                        │                  │
 │    │                        │                  └───── execution_time

--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,7 @@ Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release
 - `git:branch` (242) - The name of the current branch when in a Git repository.
 - `git:branch:cached` (red) - The name of the current branch when the data isn't fresh.
 - `git:action` (242) - The current action in progress (cherry-pick, rebase, etc.) when in a Git repository.
+- `git:branch:dirty` (218) - The asterisk showing the branch is dirty.
 - `host` (242) - The hostname when on a remote machine.
 - `path` (blue) - The current path, for example, `PWD`.
 - `prompt:error` (red) - The `PURE_PROMPT_SYMBOL` when the previous command has *failed*.

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release
 - `git:branch` (242) - The name of the current branch when in a Git repository.
 - `git:branch:cached` (red) - The name of the current branch when the data isn't fresh.
 - `git:action` (242) - The current action in progress (cherry-pick, rebase, etc.) when in a Git repository.
-- `git:branch:dirty` (218) - The asterisk showing the branch is dirty.
+- `git:dirty` (218) - The asterisk showing the branch is dirty.
 - `host` (242) - The hostname when on a remote machine.
 - `path` (blue) - The current path, for example, `PWD`.
 - `prompt:error` (red) - The `PURE_PROMPT_SYMBOL` when the previous command has *failed*.


### PR DESCRIPTION
I added an option to define the coloring of only the asterisk on the git branch, because I tend to overlook it, if it is the same color