### PR TITLE
Use ellipsis for continuation prompt (PS2)

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -701,8 +701,8 @@ prompt_pure_setup() {
 	# Prompt turns red if the previous command didn't exit with 0.
 	PROMPT+='%(?.%F{$prompt_pure_colors[prompt:success]}.%F{$prompt_pure_colors[prompt:error]})${prompt_pure_state[prompt]}%f '
 
-	# Indicate continuation prompt by ... and use a darker color for it.
-	PROMPT2='%F{242}... %(1_.%_ .%_)%f%(?.%F{magenta}.%F{red})${prompt_pure_state[prompt]}%f '
+	# Indicate continuation prompt by … and use a darker color for it.
+	PROMPT2='%F{242}%_… %f%(?.%F{magenta}.%F{red})${prompt_pure_state[prompt]}%f '
 
 	# Store prompt expansion symbols for in-place expansion via (%). For
 	# some reason it does not work without storing them in a variable first.


### PR DESCRIPTION
I had a go at tweaking the PS2 prompt that have found unbalanced. Putting the ellipsis just before the prompt symbol looks more boring and replacing the 3 dots with an UTF-8 character reduce the line width. Related with the discussion at https://github.com/sindresorhus/pure/pull/323.
![2019-08-23T17:25:25+02:00](https://user-images.githubusercontent.com/5525646/63604420-f753ad80-c5cb-11e9-8eb7-6c86a64f15d4.png)
On the left you can see the current style and on the right the style in this PR.

I have no strong opinion on this PR, fell free to ditch it's not to your liking.
WDYT?


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>


IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->