### PR TITLE
Move Git action after dirty with space and default color

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -143,14 +143,14 @@ prompt_pure_preprompt_render() {
 	# Set the path.
 	preprompt_parts+=('%F{${prompt_pure_colors[path]}}%~%f')
 
-	# Add Git branch and dirty status info.
+	# Git branch and dirty status info.
 	typeset -gA prompt_pure_vcs_info
 	if [[ -n $prompt_pure_vcs_info[branch] ]]; then
-		local branch="%F{$git_color}"'${prompt_pure_vcs_info[branch]}'
-		if [[ -n $prompt_pure_vcs_info[action] ]]; then
-			branch+="|%F{$prompt_pure_colors[git:action]}"'$prompt_pure_vcs_info[action]'"%F{$git_color}"
-		fi
-		preprompt_parts+=("$branch""%F{$git_dirty_color}"'${prompt_pure_git_dirty}%f')
+		preprompt_parts+=("%F{$git_color}"'${prompt_pure_vcs_info[branch]}'"%F{$git_dirty_color}"'${prompt_pure_git_dirty}%f')
+	fi
+	# Git action (e.g. "merge")
+	if [[ -n $prompt_pure_vcs_info[action] ]]; then
+		preprompt_parts+=("%F{$prompt_pure_colors[git:action]}"'$prompt_pure_vcs_info[action]%f')
 	fi
 	# Git pull/push arrows.
 	if [[ -n $prompt_pure_git_arrows ]]; then

--- a/pure.zsh
+++ b/pure.zsh
@@ -746,7 +746,7 @@ prompt_pure_setup() {
 		git:stash            cyan
 		git:branch           242
 		git:branch:cached    red
-		git:action           242
+		git:action           yellow
 		git:dirty            218
 		host                 242
 		path                 blue

--- a/pure.zsh
+++ b/pure.zsh
@@ -148,7 +148,7 @@ prompt_pure_preprompt_render() {
 	if [[ -n $prompt_pure_vcs_info[branch] ]]; then
 		preprompt_parts+=("%F{$git_color}"'${prompt_pure_vcs_info[branch]}'"%F{$git_dirty_color}"'${prompt_pure_git_dirty}%f')
 	fi
-	# Git action (e.g. "merge")
+	# Git action (for example, merge).
 	if [[ -n $prompt_pure_vcs_info[action] ]]; then
 		preprompt_parts+=("%F{$prompt_pure_colors[git:action]}"'$prompt_pure_vcs_info[action]%f')
 	fi

--- a/readme.md
+++ b/readme.md
@@ -134,18 +134,19 @@ Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release
 The following diagram shows where each color is applied on the prompt:
 
 ```
-┌───────────────────────────────────────────── path
-│          ┌────────────────────────────────── git:branch
-│          │      ┌─────────────────────────── git:action
-│          │      │       ┌─────────────────── git:dirty
-│          │      │       │ ┌───────────────── git:arrow
-│          │      │       │ │ ┌─────────────── git:stash
-│          │      │       │ │ │        ┌────── host
-│          │      │       │ │ │        │
-~/dev/pure master|rebase-i* ⇡ ≡ zaphod@heartofgold 42s
-venv ❯                        │                  │
-│    │                        │                  └───── execution_time
-│    │                        └──────────────────────── user
+┌────────────────────────────────────────────────────── user
+│      ┌─────────────────────────────────────────────── host
+│      │           ┌─────────────────────────────────── path
+│      │           │          ┌──────────────────────── git:branch
+│      │           │          │     ┌────────────────── git:dirty
+│      │           │          │     │ ┌──────────────── git:action
+│      │           │          │     │ │        ┌─────── git:arrow
+│      │           │          │     │ │        │ ┌───── git:stash
+│      │           │          │     │ │        │ │ ┌─── execution_time
+│      │           │          │     │ │        │ │ │
+zaphod@heartofgold ~/dev/pure master* rebase-i ⇡ ≡ 42s
+venv ❯
+│    │
 │    └───────────────────────────────────────────────── prompt
 └────────────────────────────────────────────────────── virtualenv (or prompt:continuation)
 ```


### PR DESCRIPTION
**Summary**
Moves the dirty indicator to be always adjacent to the branch. Separate the git action with a space instead of a pipe. Bestow a distinct default color to the git action, yellow.

This is following up to other recent changes #491 and #486. (which are great!)

I feel that the re-arranging would be a less welcome change without the default color also being changed.

Before:
![image](https://user-images.githubusercontent.com/5565418/67792127-a5555b00-fa46-11e9-9205-4ec507b65759.png)

After:
![image](https://user-images.githubusercontent.com/5565418/67791369-4b07ca80-fa45-11e9-9ed8-f2d19ef14047.png)

Of course this is all subjective but here is my rationale...

The dirty indicator should be adjacent to the branch since they are very closely related in my mind. Together they tell me the status of the working tree. The git action seems like it belongs at the end since it is a "special state", relatively uncommon, important to notice. A space and a distinct color is cleaner and more readable than a pipe.

I chose yellow instead of red (as in #486) for the git action since red looks like an error.

If these changes are agreed upon, I can update the readme too.