### PR TITLE
Guard against (ana)conda changing PS1

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -742,6 +742,10 @@ prompt_pure_setup() {
 
 	# Guard against Oh My Zsh themes overriding Pure.
 	unset ZSH_THEME
+
+	# Guard against (ana)conda changing the PS1 prompt
+	# (we manually insert the env when it's available).
+	export CONDA_CHANGEPS1=no
 }
 
 prompt_pure_setup "$@"


### PR DESCRIPTION
I evaluated if it would be feasible to only set this env variable when we're sure `conda` is present, but I could not find a good way, so I opted to make it always on (when Pure is enabled).

I also considered being clever and removing the environment variable in `precmd` and reintroducing it in `preexec` so that the user would not be aware of its presence (to avoid people wondering why it's set and where it comes from). But I'm also not too keen on adding this cleverness here.

The reason we must define it like we do now (instead of in runtime as with `$VIRTUAL_ENV`) is that `conda` does not retroactively obey this setting. It needs to be set before `conda` is loaded, or after we've modified `PS1` to prevent `conda` from modifying it at some point further down the line.

Fixes #515.