### PR TITLE
Optimize git fetch

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -292,6 +292,16 @@ prompt_pure_async_git_fetch() {
 	# Set SSH `BachMode` to disable all interactive SSH password prompting.
 	export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-"ssh"} -o BatchMode=yes"
 
+	local ref
+	ref=$(command git symbolic-ref -q HEAD)
+	local -a remote
+	remote=($(command git for-each-ref --format='%(upstream:remotename) %(refname)' $ref))
+
+	if [[ -z $remote[1] ]]; then
+		# No remote specified for this branch, skip fetch.
+		return 97
+	fi
+
 	# Default return code, which indicates Git fetch failure.
 	local fail_code=99
 
@@ -317,7 +327,13 @@ prompt_pure_async_git_fetch() {
 		fi
 	' CHLD
 
-	command git -c gc.auto=0 fetch >/dev/null &
+	# Only fetch information for the current branch and avoid
+	# fetching tags or submodules to speed up the process.
+	command git -c gc.auto=0 fetch \
+		--quiet \
+		--no-tags \
+		--recurse-submodules=no \
+		$remote &>/dev/null &
 	wait $! || return $fail_code
 
 	unsetopt monitor
@@ -487,6 +503,13 @@ prompt_pure_async_callback() {
 					prompt_pure_check_git_arrows ${(ps:\t:)output}
 					if [[ $prompt_pure_git_arrows != $REPLY ]]; then
 						typeset -g prompt_pure_git_arrows=$REPLY
+						do_render=1
+					fi
+					;;
+				97)
+					# No remote available, make sure to clear git arrows if set.
+					if [[ -n $prompt_pure_git_arrows ]]; then
+						typeset -g prompt_pure_git_arrows=
 						do_render=1
 					fi
 					;;


### PR DESCRIPTION
Only fetch information for the current branch to minimize the amount of work Pure (well, git) needs to do.

This commit also starts redirecting git stderr to `/dev/null` because in some cases git can start spewing errors like crazy (see #502). We also never use the stderr so there's no point in keeping it around.

Fixes #473.

Future work could include figuring out if we can somehow avoid one or both of the extra subshells (although, they're run in the async job so it will have minor impact).