### PR TITLE
Extend check for Emacs terminals

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -57,7 +57,7 @@ prompt_pure_set_title() {
 	setopt localoptions noshwordsplit
 
 	# Emacs terminal does not support settings the title.
-	(( ${+EMACS} )) && return
+	(( ${+EMACS} || ${+INSIDE_EMACS} )) && return
 
 	case $TTY in
 		# Don't set title over serial console.


### PR DESCRIPTION
Fixes display within Emacs for more recent versions where shell use of the EMACS env var has been deprecated. Deprecation notice is here:

- https://github.com/emacs-mirror/emacs/blob/d0e2a341dd9a9a365fd311748df024ecb25b70ec/etc/NEWS.25#L1240-L1244