### PR TITLE
Update Zim installation instructions in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -202,9 +202,7 @@ Add `prompt pure` to your `~/.zpreztorc`.
 
 ### [zim](https://github.com/Eriner/zim)
 
-Pure is bundled with Zim. No need to install it.
-
-Set `zprompt_theme='pure'` in `~/.zimrc`.
+Add `zmodule sindresorhus/pure --source async.zsh --source pure.zsh` to your `.zimrc` and run `zimfw install`.
 
 ### [antigen](https://github.com/zsh-users/antigen)
 


### PR DESCRIPTION
Zim 1.0.0, just released, now has a built-in plugin manager, making it the first project for Zsh that is both a set of community-maintained modules with a default installation (like on-my-zsh and prezto) and a plugin manager (like antigen and zplug).  \o/