### PR TITLE
Move user@host to beginning of prompt

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -129,6 +129,9 @@ prompt_pure_preprompt_render() {
 	# Initialize the preprompt array.
 	local -a preprompt_parts
 
+    # Username and machine, if applicable.
+	[[ -n $prompt_pure_state[username] ]] && preprompt_parts+=($prompt_pure_state[username])
+
 	# Set the path.
 	preprompt_parts+=('%F{${prompt_pure_colors[path]}}%~%f')
 
@@ -146,8 +149,6 @@ prompt_pure_preprompt_render() {
 		preprompt_parts+=('%F{$prompt_pure_colors[git:arrow]}${prompt_pure_git_arrows}%f')
 	fi
 
-	# Username and machine, if applicable.
-	[[ -n $prompt_pure_state[username] ]] && preprompt_parts+=($prompt_pure_state[username])
 	# Execution time.
 	[[ -n $prompt_pure_cmd_exec_time ]] && preprompt_parts+=('%F{$prompt_pure_colors[execution_time]}${prompt_pure_cmd_exec_time}%f')
 


### PR DESCRIPTION
This makes it far easier to notice that one is root or SSHed because the user@host string is first and it doesn’t move across the screen as one traverses long directory trees.

Before:

<img width="350" alt="Screen Shot 2020-02-12 at 22 31 43" src="https://user-images.githubusercontent.com/1076597/74399129-b9e81400-4de7-11ea-8c02-8640f9115b21.png">

After:

<img width="347" alt="Screen Shot 2020-02-12 at 22 31 22" src="https://user-images.githubusercontent.com/1076597/74399144-bf455e80-4de7-11ea-8be1-3663817faba5.png">


I can update the readme if these changes are agreeable.