### PR TITLE
display non-zero exit code

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -163,6 +163,8 @@ prompt_pure_preprompt_render() {
 
 	# Execution time.
 	[[ -n $prompt_pure_cmd_exec_time ]] && preprompt_parts+=('%F{$prompt_pure_colors[execution_time]}${prompt_pure_cmd_exec_time}%f')
+	# Print non-zero exit code
+	preprompt_parts+=('%F{red}%(?..✘ $?)%f')
 
 	local cleaned_ps1=$PROMPT
 	local -H MATCH MBEGIN MEND


### PR DESCRIPTION
Would you mind adding an option for displaying non-zero exit codes? I am aware that non-zero exit codes are already being indicated by the red prompt sign, however, that is not very legible. Exit codes are valuable while tinkering compound commands. Thanks!