### PR TITLE
Respect Git config `status.showUntrackedFiles`

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -283,11 +283,15 @@ prompt_pure_async_vcs_info() {
 prompt_pure_async_git_dirty() {
 	setopt localoptions noshwordsplit
 	local untracked_dirty=$1
+	local untracked_git_mode=$(command git config --get status.showUntrackedFiles)
+	if [[ "$untracked_git_mode" != 'no' ]]; then
+		untracked_git_mode='normal'
+	fi
 
 	if [[ $untracked_dirty = 0 ]]; then
 		command git diff --no-ext-diff --quiet --exit-code
 	else
-		test -z "$(command git --no-optional-locks status --porcelain --ignore-submodules -unormal)"
+		test -z "$(command git --no-optional-locks status --porcelain --ignore-submodules -u${untracked_git_mode})"
 	fi
 
 	return $?


### PR DESCRIPTION
I use the git config option

```
git config --local status.showUntrackedFiles no
```

in a git repo that tracks files in my `$HOME`, so that `git status` doesn't show me files that I don't care to track. However, I like seeing a dirty branch indicator when there are untracked files in my other git repos, so I do not set the environment variable `PURE_GIT_UNTRACKED_DIRTY`.

These settings result in the dirty indicator in the prompt to always be on when in my `$HOME` dotfiles git repository.

This PR just makes the prompt respect the `status.showUntrackedFiles` setting, and if unset respects the environment variable.

Let me know what you think!