### PR TITLE
Eliminate unnecessary Git locking

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -287,7 +287,7 @@ prompt_pure_async_git_dirty() {
 	if [[ $untracked_dirty = 0 ]]; then
 		command git diff --no-ext-diff --quiet --exit-code
 	else
-		test -z "$(command git status --porcelain --ignore-submodules -unormal)"
+		test -z "$(command git status --no-optional-locks --porcelain --ignore-submodules -unormal)"
 	fi
 
 	return $?

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ Most prompts are cluttered, ugly and slow. I wanted something visually pleasing 
 
 ## Install
 
-Can be installed with `npm` or manually. Requires Git 2.0.0+ and ZSH 5.2+. Older versions of ZSH are known to work, but they are **not** recommended.
+Can be installed with `npm` or manually. Requires Git 2.15.2+ and ZSH 5.2+. Older versions of ZSH are known to work, but they are **not** recommended.
 
 ### npm
 


### PR DESCRIPTION
`--no-optional-locks` helps ensure status is a non-blocking operation. Super helpful for large repos. This ensures you can execute git commands while pure is updating git status async.

There's a nice explanation about exactly what this does under the git-status manpage under "Background Refresh"