### PR TITLE
Fix '--no-optional-locks' argument position

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -287,7 +287,7 @@ prompt_pure_async_git_dirty() {
 	if [[ $untracked_dirty = 0 ]]; then
 		command git diff --no-ext-diff --quiet --exit-code
 	else
-		test -z "$(command git status --no-optional-locks --porcelain --ignore-submodules -unormal)"
+		test -z "$(command git --no-optional-locks status --porcelain --ignore-submodules -unormal)"
 	fi
 
 	return $?


### PR DESCRIPTION
The `--no-optional-locks` option added in 3a70426 should be placed before `status`, as per the [git status documentation](https://git-scm.com/docs/git-status#_background_refresh), since this is an option of git, and not git-status.