### PR TITLE
Allow extra data from a _pure_custom_postpath function

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -137,6 +137,14 @@ prompt_pure_preprompt_render() {
 	# Set the path.
 	preprompt_parts+=('%F{${prompt_pure_colors[path]}}%~%f')
 
+  # Allow extra data from a _pure_custom_postpath function
+	if typeset -f _pure_custom_postpath > /dev/null; then
+		local custom_postpath="$(_pure_custom_postpath)"
+		if [[ -n "$custom_postpath" ]]; then
+			preprompt_parts+=("${custom_postpath}%f")
+		fi
+	fi
+
 	# Git branch and dirty status info.
 	typeset -gA prompt_pure_vcs_info
 	if [[ -n $prompt_pure_vcs_info[branch] ]]; then


### PR DESCRIPTION
When using [aws-vault](https://github.com/99designs/aws-vault), it's sometimes very nice to know which profile is active. I've previously used other (slower) prompts, but I really missed having this data in pure.

However, I realise that adding support for a ton of third party stuff is not the goal of this project, so I was wondering if a simple function "plugin" hook could be added? This pull request very simply checks for a function named `_pure_custom_postpath`, and if it exists, it's invoked and the output is appended after the `path` part in the prompt.

As there's a note in the readme saying ...

> Makes an excellent starting point for your own custom prompt.

... I assume that the threshold for adding stuff to pure itself is quite high, so if this is something you explicitly don't want to add I fully understand that. I'm also open to different implementations or ideas for how to potentially make pure "pluggable". 