### PR TITLE
Show user@host when running in a container

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -696,7 +696,7 @@ prompt_pure_state_setup() {
 
 # Return true if executing inside a Docker or LXC container.
 prompt_pure_is_inside_container() {
-	([[ -r /proc/1/cgroup ]] && $(grep -q -E "(lxc|docker)" /proc/1/cgroup )) \
+	([[ -r /proc/1/cgroup ]] && grep -q -E "(lxc|docker)" /proc/1/cgroup ) \
 		|| [[ "$container" == "lxc" ]]
 }
 

--- a/pure.zsh
+++ b/pure.zsh
@@ -794,6 +794,7 @@ prompt_pure_setup() {
 		virtualenv           242
 	)
 	prompt_pure_colors=("${(@kv)prompt_pure_colors_default}")
+
 	add-zsh-hook precmd prompt_pure_precmd
 	add-zsh-hook preexec prompt_pure_preexec
 

--- a/pure.zsh
+++ b/pure.zsh
@@ -680,6 +680,9 @@ prompt_pure_state_setup() {
 	# Show `username@host` if logged in through SSH.
 	[[ -n $ssh_connection ]] && username='%F{$prompt_pure_colors[user]}%n%f'"$hostname"
 
+	# Show `username@host` if inside an LXC container.
+	(( $(env | grep -c 'container=lxc') > 0 )) && username='%F{$prompt_pure_colors[user]}%n%f'"$hostname"
+
 	# Show `username@host` if root, with username in default color.
 	[[ $UID -eq 0 ]] && username='%F{$prompt_pure_colors[user:root]}%n%f'"$hostname"
 

--- a/pure.zsh
+++ b/pure.zsh
@@ -696,8 +696,8 @@ prompt_pure_state_setup() {
 
 # Return true if executing inside a Docker or LXC container.
 prompt_pure_is_inside_container() {
-	( [[ -r /proc/1/cgroup ]] && (( $(grep --count --extended-regexp "(lxc|docker)" /proc/1/cgroup ) > 0 )) ) ||
-		(( $(env | grep --count 'container=lxc') > 0 ))
+	([[ -r /proc/1/cgroup ]] && $(grep -q -E "(lxc|docker)" /proc/1/cgroup )) \
+		|| [[ "$container" == "lxc" ]]
 }
 
 prompt_pure_system_report() {

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ Most prompts are cluttered, ugly and slow. We wanted something visually pleasing
 - Indicates when you have unpushed/unpulled `git` commits with up/down arrows. *(Check is done asynchronously!)*
 - Prompt character turns red if the last command didn't exit with `0`.
 - Command execution time will be displayed if it exceeds the set threshold.
-- Username and host only displayed when in an SSH session.
+- Username and host only displayed when in an SSH session or a container.
 - Shows the current path in the title and the [current folder & command](screenshot-title-cmd.png) when a process is running.
 - Support VI-mode indication by reverse prompt symbol (Zsh 5.3+).
 - Makes an excellent starting point for your own custom prompt.


### PR DESCRIPTION
## Issue
When running a shell inside a docker or LXC container, the pure prompt does not display **user@hostname** as when logged in to a remote computer via SSH.

## Fix
After executing a command on the wrong LXC container yesterday, I found a few reliable methods for determining whether the shell is executing inside a container.
1. In LXC, the environment contains `container=lxc`.
2. In docker and sometimes in LXC, the cgroup for the `init` process indicates "docker" or "lxc".

After the fix, the pure prompt retains the default behavior which hides **user@host** when physically logged in to a computer.

## Testing

LXC:
```
❮ lxc ubuntu dotfile-tester

ubuntu@dotfile-tester ~
❯
```
Ubuntu 20.04 (bare metal):
```
❮ ssh nuc
Welcome to Ubuntu 20.04.1 LTS (GNU/Linux 5.4.0-45-generic x86_64)
...
Last login: Thu Sep 17 18:30:41 2020 from 192.168.1.178

tim@nuc ~
❯
```
OS X Catlina (physical computer, attached with keyboard:
```
❯ hostname
mac-mini

~
❯
```
Docker container:
```
❯ ls
Dockerfile          LICENSE

root@50867f260801 ~
❯
```