### PR TITLE
Update zsh-async to v1.8.4

### DIFF
--- a/async.zsh
+++ b/async.zsh
@@ -3,12 +3,12 @@
 #
 # zsh-async
 #
-# version: 1.8.3
+# version: v1.8.4
 # author: Mathias Fredriksson
 # url: https://github.com/mafredri/zsh-async
 #
 
-typeset -g ASYNC_VERSION=1.8.3
+typeset -g ASYNC_VERSION=1.8.4
 # Produce debug output from zsh-async when set to 1.
 typeset -g ASYNC_DEBUG=${ASYNC_DEBUG:-0}
 
@@ -531,7 +531,7 @@ async_flush_jobs() {
 # 	-p pid to notify (defaults to current pid)
 #
 async_start_worker() {
-	setopt localoptions noshwordsplit
+	setopt localoptions noshwordsplit noclobber
 
 	local worker=$1; shift
 	local -a args
@@ -541,13 +541,6 @@ async_start_worker() {
 	typeset -gA ASYNC_PTYS
 	typeset -h REPLY
 	typeset has_xtrace=0
-
-	# Make sure async worker is started without xtrace
-	# (the trace output interferes with the worker).
-	[[ -o xtrace ]] && {
-		has_xtrace=1
-		unsetopt xtrace
-	}
 
 	if [[ -o interactive ]] && [[ -o zle ]]; then
 		# Inform the worker to ignore the notify flag and that we're
@@ -567,17 +560,27 @@ async_start_worker() {
 	# reassigned to /dev/null by the reassignment done inside the async
 	# worker.
 	# See https://github.com/mafredri/zsh-async/issues/35.
-	integer errfd
+	integer errfd=-1
 	exec {errfd}>&2
-	zpty -b $worker _async_worker -p $$ $args 2>&$errfd || {
-		exec {errfd}>& -
-		async_stop_worker $worker
-		return 1
+
+	# Make sure async worker is started without xtrace
+	# (the trace output interferes with the worker).
+	[[ -o xtrace ]] && {
+		has_xtrace=1
+		unsetopt xtrace
 	}
-	exec {errfd}>& -
+
+	zpty -b $worker _async_worker -p $$ $args 2>&$errfd
+	local ret=$?
 
 	# Re-enable it if it was enabled, for debugging.
 	(( has_xtrace )) && setopt xtrace
+	exec {errfd}>& -
+
+	if (( ret )); then
+		async_stop_worker $worker
+		return 1
+	fi
 
 	if ! is-at-least 5.0.8; then
 		# For ZSH versions older than 5.0.8 we delay a bit to give


### PR DESCRIPTION
- v1.8.3: Bump zsh-async, to fix the issue where people sometimes loose their stderr output.
- v1.8.4: Fixes initialization issue when user has the option noclobber enabled.

Closes #547
Closes #550
