### PR TITLE
Add zsh-async version to system report

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -712,6 +712,7 @@ prompt_pure_system_report() {
 	for k v in "${(@kv)prompt_pure_state}"; do
 		print - "    - $k: \`${(q)v}\`"
 	done
+	print - "- zsh-async version: ${ASYNC_VERSION}"
 	print - "- PROMPT: \`$(typeset -p PROMPT)\`"
 	print - "- Colors: \`$(typeset -p prompt_pure_colors)\`"
 	print - "- Virtualenv: \`$(typeset -p VIRTUAL_ENV_DISABLE_PROMPT)\`"


### PR DESCRIPTION
This change can help catch issues like #550 and informs us if someone is using a different version than bundled.