### PR TITLE
Use GIT_OPTIONAL_LOCKS=0 instead of --no-optional-locks

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -291,7 +291,7 @@ prompt_pure_async_git_dirty() {
 	if [[ $untracked_dirty = 0 ]]; then
 		command git diff --no-ext-diff --quiet --exit-code
 	else
-		test -z "$(command git --no-optional-locks status --porcelain --ignore-submodules -u${untracked_git_mode})"
+		test -z "$(GIT_OPTIONAL_LOCKS=0 command git status --porcelain --ignore-submodules -u${untracked_git_mode})"
 	fi
 
 	return $?


### PR DESCRIPTION
I still access some servers with old versions of git, and #549 / #553 silently breaks Pure functionality when the `--no-optional-locks` option is unavailable.

This gives us backwards-compatibility with old versions of git.

From `man git`:

```
       --no-optional-locks
           Do not perform optional operations that require locks. This
	   is equivalent to setting the GIT_OPTIONAL_LOCKS to 0.
```

**EDIT:** With this we could lower the required `git` version in the Pure readme, for instance `1.9.1` is working just fine.