### PR TITLE
Change whether or not is inside container check way to pure zsh

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -702,7 +702,7 @@ prompt_pure_state_setup() {
 # Return true if executing inside a Docker or LXC container.
 prompt_pure_is_inside_container() {
 	local -r cgroup_file='/proc/1/cgroup'
-	[[ -r "$cgroup_file" && -n "${(M)$(< $cgroup_file):#*(lxc|docker)*}" ]] \
+	[[ -r "$cgroup_file" && "$(< $cgroup_file)" = *(lxc|docker)* ]] \
 		|| [[ "$container" == "lxc" ]]
 }
 

--- a/pure.zsh
+++ b/pure.zsh
@@ -701,7 +701,8 @@ prompt_pure_state_setup() {
 
 # Return true if executing inside a Docker or LXC container.
 prompt_pure_is_inside_container() {
-	([[ -r /proc/1/cgroup ]] && grep -q -E "(lxc|docker)" /proc/1/cgroup ) \
+	local -r cgroup_file='/proc/1/cgroup'
+	[[ -r "$cgroup_file" && -n "${(M)$(< $cgroup_file):#*(lxc|docker)*}" ]] \
 		|| [[ "$container" == "lxc" ]]
 }
 


### PR DESCRIPTION
It is a little faster(0.001s ~ 0.004s) than before due to no need to call a grep command. Also, no need to consider which version of grep is installed(GNU, BSD, Busybox, or others?).
