### PR TITLE
Do not show hostname when running in GitHub Codespaces

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -692,7 +692,7 @@ prompt_pure_state_setup() {
 	# Show `username@host` if logged in through SSH.
 	[[ -n $ssh_connection ]] && username='%F{$prompt_pure_colors[user]}%n%f'"$hostname"
 
-	# Show `username@host` if inside a container and not in codespaces.
+	# Show `username@host` if inside a container and not in GitHub Codespaces.
 	[[ -z "${CODESPACES}" ]] && prompt_pure_is_inside_container && username='%F{$prompt_pure_colors[user]}%n%f'"$hostname"
 
 	# Show `username@host` if root, with username in default color.

--- a/pure.zsh
+++ b/pure.zsh
@@ -692,8 +692,8 @@ prompt_pure_state_setup() {
 	# Show `username@host` if logged in through SSH.
 	[[ -n $ssh_connection ]] && username='%F{$prompt_pure_colors[user]}%n%f'"$hostname"
 
-	# Show `username@host` if inside a container.
-	prompt_pure_is_inside_container && username='%F{$prompt_pure_colors[user]}%n%f'"$hostname"
+	# Show `username@host` if inside a container and not in codespaces.
+	[[ -z "${CODESPACES}" ]] && prompt_pure_is_inside_container && username='%F{$prompt_pure_colors[user]}%n%f'"$hostname"
 
 	# Show `username@host` if root, with username in default color.
 	[[ $UID -eq 0 ]] && username='%F{$prompt_pure_colors[user:root]}%n%f'"$hostname"


### PR DESCRIPTION
When running in GitHub Codespaces pure thinks it's running inside a container (correctly) but we don't need the codespaces hostname when using the integrated terminal.

Tested this change using my dotfiles and the default codespaces image.