### PR TITLE
Improve Apple Silicon compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
 		}
 	],
 	"scripts": {
-		"postinstall": "PURE_DEST=/usr/local/share/zsh/site-functions npm run --silent postinstall-link && exit 0; PURE_DEST=\"$PWD/functions\" npm run postinstall-link && npm run postinstall-fail-instructions",
+		"postinstall": "if [[ -e /opt/homebrew/bin/zsh ]]; then PURE_DEST=/opt/homebrew/share/zsh/site-functions npm run --silent postinstall-link && exit 0; elif [[ -e /usr/local/bin/zsh ]]; then PURE_DEST=/usr/local/share/zsh/site-functions npm run --silent postinstall-link && exit 0; elif [[ -e /bin/zsh ]] || [[ -e /usr/bin/zsh ]]; then PURE_DEST=/usr/share/zsh/site-functions npm run --silent postinstall-link && exit 0; fi; PURE_DEST=\"$PWD/functions\" npm run --silent postinstall-link && npm run --silent postinstall-fail-instructions",
 		"postinstall-link": "mkdir -p \"$PURE_DEST\" && ln -sf \"$PWD/pure.zsh\" \"$PURE_DEST/prompt_pure_setup\" && ln -sf \"$PWD/async.zsh\" \"$PURE_DEST/async\"",
-		"postinstall-fail-instructions": "echo \"ERROR: Could not automagically symlink the prompt. Either:\\n1. Check out the readme on how to do it manually: https://github.com/sindresorhus/pure#manually\\n2. Or add the following to your \\`.zshrc\\`:\\n\\n    fpath+=('$PWD/functions')\"",
+		"postinstall-fail-instructions": "echo \"\\nERROR: Could not automagically symlink the prompt. You can either:\\n\\n1. Add the following to your \\`.zshrc\\`:\\n\\n    fpath+=('$PWD/functions')\\n\\n2. Or check out the readme on how to do it manually: https://github.com/sindresorhus/pure#manually\"",
 		"version": "sed -i '' -e 's/prompt_pure_state\\[version\\]=.*/prompt_pure_state[version]=\"'\"$npm_package_version\"'\"/' pure.zsh && git add pure.zsh"
 	},
 	"files": [


### PR DESCRIPTION
On M1 Macs, the Homebrew path has changed to `/opt/homebrew` so we check at which path zsh is present.

Additionally we try to install into standard unix path if present, however, this will likely only help people installing via `sudo`.

Finally, the error text has been updated to prioritize updating `.zshrc` instead of doing a manual install.

Fixes #584.

---

Example output of updated error text (where `/usr/local/bin/zsh` and `/opt/homebrew/bin/zsh` is not present):

```console
❯ npm run --silent postinstall
ln: /usr/share/zsh/site-functions/prompt_pure_setup: Operation not permitted

ERROR: Could not automagically symlink the prompt. You can either:

1. Add the following to your `.zshrc`:

    fpath+=('/Users/maf/Code/pure/functions')

2. Or check out the readme on how to do it manually: https://github.com/sindresorhus/pure#manually
```