### PR TITLE
Remove $ prompts from install commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,16 +71,16 @@ Can be installed with `npm` or manually. Requires Git 2.15.2+ and ZSH 5.2+. Olde
 
 ### npm
 
-```console
-$ npm install --global pure-prompt
+```sh
+npm install --global pure-prompt
 ```
 
 That's it. Skip to [Getting started](#getting-started).
 
 ### [Homebrew](https://brew.sh)
 
-```console
-$ brew install pure
+```sh
+brew install pure
 ```
 
 ### Manually


### PR DESCRIPTION
Especially now that GitHub automatically adds text-copy icons to fenced code blocks, it makes sense to show the install commands in `sh` format and without the leading `$` prompts. That way, they can just be copy-pasted and run, without having to edit out the leading `$` first.
