### PR TITLE
Update Homebrew install instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,7 @@ git clone https://github.com/sindresorhus/pure.git "$HOME/.zsh/pure"
 2. Add the path of the cloned repo to `$fpath` in `$HOME/.zshrc`.
 ```sh
 # .zshrc
-fpath+=$HOME/.zsh/pure
+fpath+=($HOME/.zsh/pure)
 ```
 
 ## Getting started

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,12 @@ That's it. Skip to [Getting started](#getting-started).
 brew install pure
 ```
 
+If you're not using ZSH from Homebrew (`brew install zsh` and `$(brew --prefix)/bin/zsh`), you must also add the site-functions to your `fpath` in `$HOME/.zshrc`:
+
+```sh
+fpath+=("$(brew --prefix)/share/zsh/site-functions")
+```
+
 ### Manually
 
 1. Clone this repo somewhere. Here we'll use `$HOME/.zsh/pure`.


### PR DESCRIPTION
This PR fixes `brew install pure` via additional documentation.

This is really a Homebrew bug, ZSH is a complicated dependency.

- If a user uses system ZSH, it's not sufficient to install to Homebrew ZSH site-functions
- If a user has installed Homebrew ZSH, the user is still not guaranteed to be using Homebrew ZSH (i.e. via `chsh`)
- The user is never informed about this discrepancy

So essentially, Homebrew needs additional documentation or checks to ensure the user can use the installed functionality. I thought about opening an issue over at Homebrew, but wasn't sure where to put it and the disclaimers of getting banned kinda put me off...

Closes #621
