### PR TITLE
Add a reference to Starship-Pure in the ports section of readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -293,7 +293,8 @@ See [FAQ Archive](https://github.com/sindresorhus/pure/wiki/FAQ-Archive) for pre
 	- [talal/mimir](https://github.com/talal/mimir) - Pure-inspired prompt in Go with Kubernetes and OpenStack cloud support. Not intended to have feature parity.
 - **PowerShell**
 	- [nickcox/pure-pwsh](https://github.com/nickcox/pure-pwsh/) - PowerShell/PS Core implementation of the Pure prompt.
-
+- **Starship (cross-shell)**
+	- [charitarthchugh/starship-pure](https://github.com/charitarthchugh/starship-pure) - Configuration file for Starship, a cross-shell prompt, that makes it look like Pure
 ## Team
 
 [![Sindre Sorhus](https://github.com/sindresorhus.png?size=100)](https://sindresorhus.com) | [![Mathias Fredriksson](https://github.com/mafredri.png?size=100)](https://github.com/mafredri)

--- a/readme.md
+++ b/readme.md
@@ -294,7 +294,8 @@ See [FAQ Archive](https://github.com/sindresorhus/pure/wiki/FAQ-Archive) for pre
 - **PowerShell**
 	- [nickcox/pure-pwsh](https://github.com/nickcox/pure-pwsh/) - PowerShell/PS Core implementation of the Pure prompt.
 - **Starship (cross-shell)**
-	- [Pure Preset](https://starship.rs/presets/pure-preset.html) - Configuration file for Starship, a cross-shell prompt, that makes it look like Pure
+	- [Pure Preset](https://starship.rs/presets/pure-preset.html) - Configuration file for Starship, a cross-shell prompt, that makes it look like Pure.
+
 ## Team
 
 [![Sindre Sorhus](https://github.com/sindresorhus.png?size=100)](https://sindresorhus.com) | [![Mathias Fredriksson](https://github.com/mafredri.png?size=100)](https://github.com/mafredri)

--- a/readme.md
+++ b/readme.md
@@ -294,7 +294,7 @@ See [FAQ Archive](https://github.com/sindresorhus/pure/wiki/FAQ-Archive) for pre
 - **PowerShell**
 	- [nickcox/pure-pwsh](https://github.com/nickcox/pure-pwsh/) - PowerShell/PS Core implementation of the Pure prompt.
 - **Starship (cross-shell)**
-	- [charitarthchugh/starship-pure](https://github.com/charitarthchugh/starship-pure) - Configuration file for Starship, a cross-shell prompt, that makes it look like Pure
+	- [Pure Preset](https://starship.rs/presets/pure-preset.html) - Configuration file for Starship, a cross-shell prompt, that makes it look like Pure
 ## Team
 
 [![Sindre Sorhus](https://github.com/sindresorhus.png?size=100)](https://sindresorhus.com) | [![Mathias Fredriksson](https://github.com/mafredri.png?size=100)](https://github.com/mafredri)


### PR DESCRIPTION
I have created a config for Starship, a cross shell prompt, that tries to mimic Pure. If any configuration settings needs to be updated, I would be happy to do so to match Pure. 

EDIT:
There is an official preset that mimics Pure more closely in the Starship Docs. The only downside in my opinion to this is that it also limits language support to languages that pure supports.