### PR TITLE
Add configuration option for mapping username/hostname per-host

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -66,7 +66,7 @@ prompt_pure_set_title() {
 
 	# Show hostname if connected via SSH.
 	local hostname=
-	if [[ -n $prompt_pure_state[username] ]]; then
+	if [[ -n $prompt_pure_state[userhost] ]]; then
 		# Expand in-place in case ignore-escape is used.
 		hostname="${(%):-(%m) }"
 	fi
@@ -137,7 +137,7 @@ prompt_pure_preprompt_render() {
 	fi
 
 	# Username and machine, if applicable.
-	[[ -n $prompt_pure_state[username] ]] && preprompt_parts+=($prompt_pure_state[username])
+	[[ -n $prompt_pure_state[userhost] ]] && preprompt_parts+=($prompt_pure_state[userhost])
 
 	# Set the path.
 	preprompt_parts+=('%F{${prompt_pure_colors[path]}}%~%f')
@@ -711,7 +711,7 @@ prompt_pure_state_setup() {
 	typeset -gA prompt_pure_state
 	prompt_pure_state[version]="1.20.1"
 	prompt_pure_state+=(
-		username "$username"
+		userhost "$username"
 		prompt	 "${PURE_PROMPT_SYMBOL:-❯}"
 	)
 }

--- a/pure.zsh
+++ b/pure.zsh
@@ -145,7 +145,7 @@ prompt_pure_produce_userhost_to_vars() {
 	typeset -gA PURE_HOST_MAP
 
 	# 'user-to-replace:usethisname@thishostinstead anotheruser:another@replacement'
-	local replacements="$PURE_HOST_MAP[$rawhost]"
+	local replacements="${PURE_HOST_MAP[$rawhost]:-$PURE_HOST_MAP['*']}"
 	if [[ -n "$replacements" ]]; then
 		rawuser=`print -P '%n'`
 

--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,7 @@ prompt pure
 | **`PURE_GIT_DOWN_ARROW`**        | Defines the git down arrow symbol.                                                             | `⇣`            |
 | **`PURE_GIT_UP_ARROW`**          | Defines the git up arrow symbol.                                                               | `⇡`            |
 | **`PURE_GIT_STASH_SYMBOL`**      | Defines the git stash symbol.                                                                  | `≡`            |
+| **`PURE_HOST_MAP`**              | Used to change the user or hostname shown on SSH targets. (See [Hostnames](#hostnames) below.) |                |
 
 ## Zstyle options
 
@@ -197,6 +198,39 @@ If you can't use such terminal, the module [`zsh/nearcolor`](http://zsh.sourcefo
 # .zshrc
 zmodload zsh/nearcolor
 zstyle :prompt:pure:path color '#FF0000'
+```
+
+## Hostnames
+
+You can configure the `user@host.blah` portion of the prompt on machines you don't control with the "hostname map". If set, this must be an (associative array)[https://zsh.sourceforge.io/Doc/Release/Parameters.html#Array-Parameters]; that is, you must declare it ahead-of-time with `typeset -gA`:
+
+```sh
+typeset -gA PURE_HOST_MAP
+PURE_HOST_MAP[somehost]="..."
+```
+
+Each entry in this array is a hostname on which you wish to configure the naming of. Within that entry, one includes both a username-to-replace, as well as the replacement hostname-and-user. (This layout is optimized for shell-startup performance; blame zsh for a conspicuous lack of nested-associative-arrays. `:P`)
+
+As an example, if we want to replace `bob` and `alice` on `really-long-annoying-server-name`, with `b` and `a` on `rlasn` ...
+
+```sh
+typeset -gA PURE_HOST_MAP
+PURE_HOST_MAP[really-long-annoying-server-name]="bob:b@rlasn alice:a@rlasn"
+```
+
+The usernames can be left blank (effectively replacing the hostname no matter which user you login as); and you can use the hostname '*' to rename a user on all hosts:
+
+```sh
+typeset -gA PURE_HOST_MAP
+
+# Never, ever show me `really-long-annoying-server-name`
+PURE_HOST_MAP[really-long-annoying-server-name]=":@rlasn"
+
+# Shorten my username on our work-machine; but the hostname is fine as-is
+PURE_HOST_MAP[workbox]="harold-washington:ME@"
+
+# Shorten my username anywhere it appears
+PURE_HOST_MAP['*']="elliottcable:ec@"
 ```
 
 ## Example

--- a/readme.md
+++ b/readme.md
@@ -202,7 +202,7 @@ zstyle :prompt:pure:path color '#FF0000'
 
 ## Hostnames
 
-You can configure the `user@host.blah` portion of the prompt on machines you don't control with the "hostname map". If set, this must be an (associative array)[https://zsh.sourceforge.io/Doc/Release/Parameters.html#Array-Parameters]; that is, you must declare it ahead-of-time with `typeset -gA`:
+You can configure the `user@host.blah` portion of the prompt on machines you don't control with the "hostname map". If set, this must be an [associative array](https://zsh.sourceforge.io/Doc/Release/Parameters.html#Array-Parameters); that is, you must declare it ahead-of-time with `typeset -gA`:
 
 ```sh
 typeset -gA PURE_HOST_MAP

--- a/readme.md
+++ b/readme.md
@@ -218,7 +218,7 @@ typeset -gA PURE_HOST_MAP
 PURE_HOST_MAP[really-long-annoying-server-name]="bob:b@rlasn alice:a@rlasn"
 ```
 
-The usernames can be left blank (effectively replacing the hostname no matter which user you login as); and you can use the hostname '*' to rename a user on all hosts:
+The usernames can be left blank (effectively replacing the hostname no matter which user you login as); and you can use the hostname `'*'` to rename a user on all hosts:
 
 ```sh
 typeset -gA PURE_HOST_MAP


### PR DESCRIPTION
This PR implements a configuration-option that allows users to provide a mapping of replacement user- and host-names for systems they do not control, but often SSH into.

As an example, we use `nspawn` at my organization, and I do not have control over my username — this PR allows me to replace the infinitely-annoying `elliott.cable@spawnbox-febox3-elliottcable` with `ec@nspawn3`:

```sh
typeset -gA PURE_HOST_MAP
PURE_HOST_MAP[spawnbox-febox3-elliottcable]="elliott.cable:ec@nspawn3"
```

As for the rest, well, this is best understood from the [documentation I've added to the README](https://github.com/ELLIOTTCABLE/pure/tree/userhost-map#hostnames).

(Implementing this in a sufficiently-general way ended up being mildly messy; enough so that I'll understand if you don't wish to upstream this improvement. If not, I intend to main this feature in my fork; could you add `ELLIOTTCABLE/pure` to the list of maintained forks?)

This implements #488, and solves #614 and #136.