### PR TITLE
Make sure GPG-agent does not mess up the tty

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -329,6 +329,9 @@ prompt_pure_async_git_fetch() {
 	# solves issue #366
 	export GPG_TTY=$TTY
 
+	# tell the child process to not expect any input from this zpty
+	exec /dev/null > $TTY
+
 	local -a remote
 	if ((only_upstream)); then
 		local ref

--- a/pure.zsh
+++ b/pure.zsh
@@ -324,6 +324,11 @@ prompt_pure_async_git_fetch() {
 	# Set SSH `BachMode` to disable all interactive SSH password prompting.
 	export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-"ssh"} -o BatchMode=yes"
 
+	# if gpg-agent is setup to handle ssh keys for git fetch; then
+	# make sure it uses this zpty instead of corrupting the parent tty
+	# solves issue #366
+	export GPG_TTY=$TTY
+
 	local -a remote
 	if ((only_upstream)); then
 		local ref

--- a/pure.zsh
+++ b/pure.zsh
@@ -324,12 +324,11 @@ prompt_pure_async_git_fetch() {
 	# Set SSH `BachMode` to disable all interactive SSH password prompting.
 	export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-"ssh"} -o BatchMode=yes"
 
-	# if gpg-agent is setup to handle ssh keys for git fetch; then
-	# make sure it uses this zpty instead of corrupting the parent tty
-	# solves issue #366
+	# If gpg-agent is set to handle SSH keys for `git fetch`, make
+	# sure it uses this zpty instead of corrupting the parent TTY.
 	export GPG_TTY=$TTY
 
-	# tell the child process to not expect any input from this zpty
+	# Tell the child process to not expect any input from this zpty.
 	exec /dev/null > $TTY
 
 	local -a remote


### PR DESCRIPTION
When gpg-agent is used as an ssh-agent and configured with pinentry-ncurses,
it messes up the terminal immediately after you cd into a git repository with an ssh remote.

Fixes #366.

I can help you reproduce it if you ask.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#366: pinentry-ncurses in async process mangles inputs for the rest of the session](https://issuehunt.io/repos/5890857/issues/366)
---
</details>
<!-- /Issuehunt content-->