### PR TITLE
Allow customising terminal title format or disabling it altogether

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -95,7 +95,7 @@ prompt_pure_preexec() {
 	typeset -g prompt_pure_cmd_timestamp=$EPOCHSECONDS
 
 	# Shows the current directory and executed command in the title while a process is active.
-	prompt_pure_set_title 'ignore-escape' "$PWD:t: $2"
+	prompt_pure_set_title 'expand-prompt' "${PURE_PROMPT_TITLE_ACTIVE:-$PWD:t: $2}" "$@"
 
 	# Disallow Python virtualenv from updating the prompt. Set it to 12 if
 	# untouched by the user to indicate that Pure modified it. Here we use
@@ -205,7 +205,7 @@ prompt_pure_precmd() {
 	unset prompt_pure_cmd_timestamp
 
 	# Shows the full path in the title.
-	prompt_pure_set_title 'expand-prompt' '%~'
+	prompt_pure_set_title 'expand-prompt' "${PURE_PROMPT_TITLE_IDLE:-%~}" "$@"
 
 	# Modify the colors if some have changed..
 	prompt_pure_set_colors

--- a/pure.zsh
+++ b/pure.zsh
@@ -94,8 +94,10 @@ prompt_pure_preexec() {
 
 	typeset -g prompt_pure_cmd_timestamp=$EPOCHSECONDS
 
-	# Shows the current directory and executed command in the title while a process is active.
-	prompt_pure_set_title 'expand-prompt' "${PURE_PROMPT_TITLE_ACTIVE:-$PWD:t: $2}" "$@"
+	if ((${PURE_PROMPT_SET_TITLE:-1})); then
+		# Shows the current directory and executed command in the title while a process is active.
+		prompt_pure_set_title 'expand-prompt' "${PURE_PROMPT_TITLE_ACTIVE:-$PWD:t: $2}" "$@"
+	fi
 
 	# Disallow Python virtualenv from updating the prompt. Set it to 12 if
 	# untouched by the user to indicate that Pure modified it. Here we use
@@ -204,8 +206,10 @@ prompt_pure_precmd() {
 	prompt_pure_check_cmd_exec_time
 	unset prompt_pure_cmd_timestamp
 
-	# Shows the full path in the title.
-	prompt_pure_set_title 'expand-prompt' "${PURE_PROMPT_TITLE_IDLE:-%~}" "$@"
+	if ((${PURE_PROMPT_SET_TITLE:-1})); then
+		# Shows the full path in the title.
+		prompt_pure_set_title 'expand-prompt' "${PURE_PROMPT_TITLE_IDLE:-%~}" "$@"
+	fi
 
 	# Modify the colors if some have changed..
 	prompt_pure_set_colors

--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,7 @@ prompt pure
 | **`PURE_GIT_STASH_SYMBOL`**      | Defines the git stash symbol.                                                                  | `≡`            |
 | **`PURE_PROMPT_TITLE_IDLE`**     | Defines the format of the terminal title when a command is not running                         | `%~`           |
 | **`PURE_PROMPT_TITLE_ACTIVE`**   | Defines the format of the terminal title when a command is running                             | `$PWD:t: $2`   |
+| **`PURE_PROMPT_SET_TITLE`**      | Whether to set the terminal title                                                              | `1`            |
 
 ## Zstyle options
 

--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,8 @@ prompt pure
 | **`PURE_GIT_DOWN_ARROW`**        | Defines the git down arrow symbol.                                                             | `⇣`            |
 | **`PURE_GIT_UP_ARROW`**          | Defines the git up arrow symbol.                                                               | `⇡`            |
 | **`PURE_GIT_STASH_SYMBOL`**      | Defines the git stash symbol.                                                                  | `≡`            |
+| **`PURE_PROMPT_TITLE_IDLE`**     | Defines the format of the terminal title when a command is not running                         | `%~`           |
+| **`PURE_PROMPT_TITLE_ACTIVE`**   | Defines the format of the terminal title when a command is running                             | `$PWD:t: $2`   |
 
 ## Zstyle options
 


### PR DESCRIPTION
I'm sure this could be improved upon but hopefully it's useful even as a starting point.

I had to add passing the `"$@"` from the hook functions into `prompt_pure_set_title`, or it wouldn't be available to user-defined formats (which makes the `preexec` arguments `$3`, `$4`, and `$5`). I also changed `ignore-escape` to `expand-prompt`, again so a user can make use of that feature, which means the `ignore-escape` mode is never used and perhaps it could be removed?

Fixes #656