### PR TITLE
Support podman to determine inside container

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -729,6 +729,7 @@ prompt_pure_is_inside_container() {
 	[[ -r "$cgroup_file" && "$(< $cgroup_file)" = *(lxc|docker)* ]] \
 		|| [[ "$container" == "lxc" ]] \
 		|| [[ "$container" == "oci" ]] \
+		|| [[ "$container" == "podman" ]] \
 		|| [[ -r "$nspawn_file" ]]
 }
 


### PR DESCRIPTION
According to the comment, the 'container' environment variable is set to 'podman' when running in a Podman container. 

https://github.com/containers/podman/issues/3586#issuecomment-661918679