### PR TITLE
Add ability to edit the `suspended_jobs` indicator symbol

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -133,7 +133,7 @@ prompt_pure_preprompt_render() {
 
 	# Suspended jobs in background.
 	if ((${(M)#jobstates:#suspended:*} != 0)); then
-		preprompt_parts+='%F{$prompt_pure_colors[suspended_jobs]}✦'
+		preprompt_parts+='%F{$prompt_pure_colors[suspended_jobs]}${PURE_SUSPEND_SYMBOL:-✦}'
 	fi
 
 	# Username and machine, if applicable.

--- a/pure.zsh
+++ b/pure.zsh
@@ -133,7 +133,7 @@ prompt_pure_preprompt_render() {
 
 	# Suspended jobs in background.
 	if ((${(M)#jobstates:#suspended:*} != 0)); then
-		preprompt_parts+='%F{$prompt_pure_colors[suspended_jobs]}${PURE_SUSPEND_SYMBOL:-✦}'
+		preprompt_parts+='%F{$prompt_pure_colors[suspended_jobs]}${PURE_SUSPENDED_JOBS_SYMBOL:-✦}'
 	fi
 
 	# Username and machine, if applicable.

--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,7 @@ prompt pure
 | **`PURE_GIT_DELAY_DIRTY_CHECK`** | Time in seconds to delay git dirty checking when `git status` takes > 5 seconds.               | `1800` seconds |
 | **`PURE_PROMPT_SYMBOL`**         | Defines the prompt symbol.                                                                     | `❯`            |
 | **`PURE_PROMPT_VICMD_SYMBOL`**   | Defines the prompt symbol used when the `vicmd` keymap is active (VI-mode).                    | `❮`            |
+| **`PURE_SUSPENDED_JOBS_SYMBOL`** | Defines the symbol that indicates that jobs are running in the background.                     | `✦`            |
 | **`PURE_GIT_DOWN_ARROW`**        | Defines the git down arrow symbol.                                                             | `⇣`            |
 | **`PURE_GIT_UP_ARROW`**          | Defines the git up arrow symbol.                                                               | `⇡`            |
 | **`PURE_GIT_STASH_SYMBOL`**      | Defines the git stash symbol.                                                                  | `≡`            |
@@ -162,7 +163,7 @@ Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release
 - `prompt:error` (red) - The `PURE_PROMPT_SYMBOL` when the previous command has *failed*.
 - `prompt:success` (magenta) - The `PURE_PROMPT_SYMBOL` when the previous command has *succeeded*.
 - `prompt:continuation` (242) - The color for showing the state of the parser in the continuation prompt (PS2). It's the pink part in [this screenshot](https://user-images.githubusercontent.com/147409/70068574-ebc74800-15f8-11ea-84c0-8b94a4b57ff4.png), it appears in the same spot as `virtualenv`. You could for example matching both colors so that Pure has a uniform look.
-- `suspended_jobs` (red) - The `✦` symbol indicates that jobs are running in the background.
+- `suspended_jobs` (red) - The `PURE_SUSPENDED_JOBS_SYMBOL`.
 - `user` (242) - The username when on remote machine.
 - `user:root` (default) - The username when the user is root.
 - `virtualenv` (242) - The name of the Python `virtualenv` when in use.


### PR DESCRIPTION
Hello.

I'd like to request a tiny edit – allowing the user to change the `suspended_jobs` symbol in the `zshrc` like the other prompt elements.

Thanks for making this awesome prompt!

Warm regards,
Kosma
