### PR TITLE
Reset RPS1 on setup

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -890,6 +890,9 @@ prompt_pure_setup() {
 	# Guard against Oh My Zsh themes overriding Pure.
 	unset ZSH_THEME
 
+	# Reset right prompt RPS1
+	unset RPS1
+
 	# Guard against (ana)conda changing the PS1 prompt
 	# (we manually insert the env when it's available).
 	export CONDA_CHANGEPS1=no


### PR DESCRIPTION
When the system is configured to use a default zsh prompt such as `prompt walters`, the right prompt variable $RPS1 gets defined but never reset by pure.zsh. This unsets the variable on `setup`