### PR TITLE
Use --no-prune-tags in git fetch command

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -372,6 +372,7 @@ prompt_pure_async_git_fetch() {
 	command git -c gc.auto=0 fetch \
 		--quiet \
 		--no-tags \
+		--no-prune-tags \
 		--recurse-submodules=no \
 		$remote &>/dev/null &
 	wait $! || return $fail_code


### PR DESCRIPTION
Documentation for --prune-tags says:

    Before fetching, remove any local tags that no longer exist on
    the remote if --prune is enabled.  This option should be used
    more carefully, unlike --prune it will remove any local references
    (local tags) that have been created. This option is a shorthand
    for providing the explicit tag refspec along with --prune, see
    the discussion about that in its documentation.

I had fetch.prunetags set in my .gitconfig because normally I want to delete outdated tags. But I hadn't realized that this causes my newly-created local tags to be deleted. It seems harmless to use --no-prune-tags in the git fetch command.

The option was added in Git 2.17.0. Ubuntu 18.04 has 2.17.1, Debian buster has 2.20.1, RHEL 8 has 2.18.something.