### PR TITLE
Support non-Git VCS systems via external functions

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -82,7 +82,9 @@ prompt_pure_set_title() {
 }
 
 prompt_pure_preexec() {
-	if [[ -n $prompt_pure_git_fetch_pattern ]]; then
+	setopt localoptions noshwordsplit
+
+	if [[ "${prompt_pure_vcs_type}" == "git" && -n $prompt_pure_git_fetch_pattern ]]; then
 		# Detect when Git is performing pull/fetch, including Git aliases.
 		local -H MATCH MBEGIN MEND match mbegin mend
 		if [[ $2 =~ (git|hub)\ (.*\ )?($prompt_pure_git_fetch_pattern)(\ .*)?$ ]]; then
@@ -126,7 +128,7 @@ prompt_pure_preprompt_render() {
 	# Set color for Git branch/dirty status and change color if dirty checking has been delayed.
 	local git_color=$prompt_pure_colors[git:branch]
 	local git_dirty_color=$prompt_pure_colors[git:dirty]
-	[[ -n ${prompt_pure_git_last_dirty_check_timestamp+x} ]] && git_color=$prompt_pure_colors[git:branch:cached]
+	[[ -n ${prompt_pure_vcs_last_dirty_check_timestamp+x} ]] && git_color=$prompt_pure_colors[git:branch:cached]
 
 	# Initialize the preprompt array.
 	local -a preprompt_parts
@@ -145,18 +147,18 @@ prompt_pure_preprompt_render() {
 	# Git branch and dirty status info.
 	typeset -gA prompt_pure_vcs_info
 	if [[ -n $prompt_pure_vcs_info[branch] ]]; then
-		preprompt_parts+=("%F{$git_color}"'${prompt_pure_vcs_info[branch]}'"%F{$git_dirty_color}"'${prompt_pure_git_dirty}%f')
+		preprompt_parts+=("%F{$git_color}"'${prompt_pure_vcs_info[branch]}'"%F{$git_dirty_color}"'${prompt_pure_vcs_dirty}%f')
 	fi
 	# Git action (for example, merge).
 	if [[ -n $prompt_pure_vcs_info[action] ]]; then
 		preprompt_parts+=("%F{$prompt_pure_colors[git:action]}"'$prompt_pure_vcs_info[action]%f')
 	fi
 	# Git pull/push arrows.
-	if [[ -n $prompt_pure_git_arrows ]]; then
-		preprompt_parts+=('%F{$prompt_pure_colors[git:arrow]}${prompt_pure_git_arrows}%f')
+	if [[ -n $prompt_pure_vcs_arrows ]]; then
+		preprompt_parts+=('%F{$prompt_pure_colors[git:arrow]}${prompt_pure_vcs_arrows}%f')
 	fi
 	# Git stash symbol (if opted in).
-	if [[ -n $prompt_pure_git_stash ]]; then
+	if [[ -n $prompt_pure_vcs_stash ]]; then
 		preprompt_parts+=('%F{$prompt_pure_colors[git:stash]}${PURE_GIT_STASH_SYMBOL:-≡}%f')
 	fi
 
@@ -272,23 +274,30 @@ prompt_pure_async_git_aliases() {
 prompt_pure_async_vcs_info() {
 	setopt localoptions noshwordsplit
 
+	local -a vcs_list
+	# load list of vcs'es from zstyle, but default to git only
+	if ! zstyle -a ':prompt:pure:vcs_info' vcs_list 'vcs_list'; then
+		vcs_list=( git )
+	fi
 	# Configure `vcs_info` inside an async task. This frees up `vcs_info`
 	# to be used or configured as the user pleases.
-	zstyle ':vcs_info:*' enable git
+	zstyle ':vcs_info:*' enable "${vcs_list[@]}"
 	zstyle ':vcs_info:*' use-simple true
 	# Only export four message variables from `vcs_info`.
-	zstyle ':vcs_info:*' max-exports 3
-	# Export branch (%b), Git toplevel (%R), action (rebase/cherry-pick) (%a)
-	zstyle ':vcs_info:git*' formats '%b' '%R' '%a'
-	zstyle ':vcs_info:git*' actionformats '%b' '%R' '%a'
+	zstyle ':vcs_info:*' max-exports 4
+	# Export vcs type (%s), branch (%b), Git toplevel (%R), action (rebase/cherry-pick) (%a)
+	zstyle ':vcs_info:*' formats '%s' '%b' '%R' '%a'
+	zstyle ':vcs_info:*' actionformats '%s' '%b' '%R' '%a'
 
 	vcs_info
 
 	local -A info
 	info[pwd]=$PWD
-	info[branch]=${vcs_info_msg_0_//\%/%%}
-	info[top]=$vcs_info_msg_1_
-	info[action]=$vcs_info_msg_2_
+	# get vcs type without flavor (i.e. git-p4 -> git)
+	info[vcs]=${vcs_info_msg_0_/-*/}
+	info[branch]=${vcs_info_msg_1_//\%/%%}
+	info[top]=$vcs_info_msg_2_
+	info[action]=$vcs_info_msg_3_
 
 	print -r - ${(@kvq)info}
 }
@@ -423,7 +432,7 @@ prompt_pure_async_tasks() {
 	prompt_pure_async_init
 
 	# Update the current working directory of the async worker.
-	async_worker_eval "prompt_pure" builtin cd -q $PWD
+	async_worker_eval "prompt_pure" builtin cd -q "$PWD"
 
 	typeset -gA prompt_pure_vcs_info
 
@@ -432,11 +441,12 @@ prompt_pure_async_tasks() {
 		# Stop any running async jobs.
 		async_flush_jobs "prompt_pure"
 
-		# Reset Git preprompt variables, switching working tree.
-		unset prompt_pure_git_dirty
-		unset prompt_pure_git_last_dirty_check_timestamp
-		unset prompt_pure_git_arrows
-		unset prompt_pure_git_stash
+		# Reset VCS preprompt variables, switching working tree.
+		unset prompt_pure_vcs_type
+		unset prompt_pure_vcs_dirty
+		unset prompt_pure_vcs_last_dirty_check_timestamp
+		unset prompt_pure_vcs_arrows
+		unset prompt_pure_vcs_stash
 		unset prompt_pure_git_fetch_pattern
 		prompt_pure_vcs_info[branch]=
 		prompt_pure_vcs_info[top]=
@@ -454,40 +464,42 @@ prompt_pure_async_tasks() {
 prompt_pure_async_refresh() {
 	setopt localoptions noshwordsplit
 
-	if [[ -z $prompt_pure_git_fetch_pattern ]]; then
+	local vcs_type=${prompt_pure_vcs_type}
+
+	if [[ "${vcs_type}" == "git" && -z $prompt_pure_git_fetch_pattern ]]; then
 		# We set the pattern here to avoid redoing the pattern check until the
 		# working tree has changed. Pull and fetch are always valid patterns.
 		typeset -g prompt_pure_git_fetch_pattern="pull|fetch"
-		async_job "prompt_pure" prompt_pure_async_git_aliases
+		async_job "prompt_pure" "prompt_pure_async_git_aliases"
 	fi
 
-	async_job "prompt_pure" prompt_pure_async_git_arrows
+	async_job "prompt_pure" "prompt_pure_async_${vcs_type}_arrows"
 
 	# Do not perform `git fetch` if it is disabled or in home folder.
 	if (( ${PURE_GIT_PULL:-1} )) && [[ $prompt_pure_vcs_info[top] != $HOME ]]; then
 		zstyle -t :prompt:pure:git:fetch only_upstream
 		local only_upstream=$((? == 0))
-		async_job "prompt_pure" prompt_pure_async_git_fetch $only_upstream
+		async_job "prompt_pure" "prompt_pure_async_${vcs_type}_fetch" $only_upstream
 	fi
 
 	# If dirty checking is sufficiently fast,
 	# tell the worker to check it again, or wait for timeout.
-	integer time_since_last_dirty_check=$(( EPOCHSECONDS - ${prompt_pure_git_last_dirty_check_timestamp:-0} ))
+	integer time_since_last_dirty_check=$(( EPOCHSECONDS - ${prompt_pure_vcs_last_dirty_check_timestamp:-0} ))
 	if (( time_since_last_dirty_check > ${PURE_GIT_DELAY_DIRTY_CHECK:-1800} )); then
-		unset prompt_pure_git_last_dirty_check_timestamp
+		unset prompt_pure_vcs_last_dirty_check_timestamp
 		# Check check if there is anything to pull.
-		async_job "prompt_pure" prompt_pure_async_git_dirty ${PURE_GIT_UNTRACKED_DIRTY:-1}
+		async_job "prompt_pure" "prompt_pure_async_${vcs_type}_dirty" ${PURE_GIT_UNTRACKED_DIRTY:-1}
 	fi
 
 	# If stash is enabled, tell async worker to count stashes
 	if zstyle -t ":prompt:pure:git:stash" show; then
-		async_job "prompt_pure" prompt_pure_async_git_stash
+		async_job "prompt_pure" "prompt_pure_async_${vcs_type}_stash"
 	else
-		unset prompt_pure_git_stash
+		unset prompt_pure_vcs_stash
 	fi
 }
 
-prompt_pure_check_git_arrows() {
+prompt_pure_check_vcs_arrows() {
 	setopt localoptions noshwordsplit
 	local arrows left=${1:-0} right=${2:-0}
 
@@ -556,7 +568,8 @@ prompt_pure_async_callback() {
 			# Git directory. Run the async refresh tasks.
 			[[ -n $info[top] ]] && [[ -z $prompt_pure_vcs_info[top] ]] && prompt_pure_async_refresh
 
-			# Always update branch, top-level and stash.
+			# Always update vcs, branch, top-level and stash.
+			prompt_pure_vcs_type=$info[vcs]
 			prompt_pure_vcs_info[branch]=$info[branch]
 			prompt_pure_vcs_info[top]=$info[top]
 			prompt_pure_vcs_info[action]=$info[action]
@@ -569,58 +582,65 @@ prompt_pure_async_callback() {
 				prompt_pure_git_fetch_pattern+="|$output"
 			fi
 			;;
-		prompt_pure_async_git_dirty)
-			local prev_dirty=$prompt_pure_git_dirty
-			if (( code == 0 )); then
-				unset prompt_pure_git_dirty
+		prompt_pure_async_*_dirty)
+			local prev_dirty=$prompt_pure_vcs_dirty
+			# 127 means _dirty function was not defined for current vcs, assume non-dirty
+			if (( code == 0 || code == 127 )); then
+				unset prompt_pure_vcs_dirty
 			else
-				typeset -g prompt_pure_git_dirty="*"
+				typeset -g prompt_pure_vcs_dirty="*"
 			fi
 
-			[[ $prev_dirty != $prompt_pure_git_dirty ]] && do_render=1
+			[[ $prev_dirty != $prompt_pure_vcs_dirty ]] && do_render=1
 
-			# When `prompt_pure_git_last_dirty_check_timestamp` is set, the Git info is displayed
+			# When `prompt_pure_vcs_last_dirty_check_timestamp` is set, the VCS info is displayed
 			# in a different color. To distinguish between a "fresh" and a "cached" result, the
 			# preprompt is rendered before setting this variable. Thus, only upon the next
 			# rendering of the preprompt will the result appear in a different color.
-			(( $exec_time > 5 )) && prompt_pure_git_last_dirty_check_timestamp=$EPOCHSECONDS
+			(( $exec_time > 5 )) && prompt_pure_vcs_last_dirty_check_timestamp=$EPOCHSECONDS
 			;;
-		prompt_pure_async_git_fetch|prompt_pure_async_git_arrows)
-			# `prompt_pure_async_git_fetch` executes `prompt_pure_async_git_arrows`
+		prompt_pure_async_*_fetch|prompt_pure_async_*_arrows)
+			# `prompt_pure_async_vcs_fetch` executes `prompt_pure_async_vcs_arrows`
 			# after a successful fetch.
 			case $code in
 				0)
 					local REPLY
-					prompt_pure_check_git_arrows ${(ps:\t:)output}
-					if [[ $prompt_pure_git_arrows != $REPLY ]]; then
-						typeset -g prompt_pure_git_arrows=$REPLY
+					prompt_pure_check_vcs_arrows ${(ps:\t:)output}
+					if [[ $prompt_pure_vcs_arrows != $REPLY ]]; then
+						typeset -g prompt_pure_vcs_arrows=$REPLY
 						do_render=1
 					fi
 					;;
-				97)
-					# No remote available, make sure to clear git arrows if set.
-					if [[ -n $prompt_pure_git_arrows ]]; then
-						typeset -g prompt_pure_git_arrows=
+				97|127)
+					# 97: No remote available
+					# 127: Functions for current VCS have not been defined
+					# make sure to clear vcs arrows if set.
+					if [[ -n $prompt_pure_vcs_arrows ]]; then
+						typeset -g prompt_pure_vcs_arrows=
 						do_render=1
 					fi
 					;;
 				99|98)
-					# Git fetch failed.
+					# VCS fetch failed.
 					;;
 				*)
-					# Non-zero exit status from `prompt_pure_async_git_arrows`,
+					# Non-zero exit status from `prompt_pure_async_vcs_arrows`,
 					# indicating that there is no upstream configured.
-					if [[ -n $prompt_pure_git_arrows ]]; then
-						unset prompt_pure_git_arrows
+					if [[ -n $prompt_pure_vcs_arrows ]]; then
+						unset prompt_pure_vcs_arrows
 						do_render=1
 					fi
 					;;
 			esac
 			;;
-		prompt_pure_async_git_stash)
-			local prev_stash=$prompt_pure_git_stash
-			typeset -g prompt_pure_git_stash=$output
-			[[ $prev_stash != $prompt_pure_git_stash ]] && do_render=1
+		prompt_pure_async_*_stash)
+			local prev_stash=$prompt_pure_vcs_stash
+			if (( code == 0 )); then
+				typeset -g prompt_pure_vcs_stash="$output"
+			else
+				typeset -g prompt_pure_vcs_stash=""
+			fi
+			[[ $prev_stash != $prompt_pure_vcs_stash ]] && do_render=1
 			;;
 	esac
 

--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,69 @@ You can set Pure to only `git fetch` the upstream branch of the current local br
 
 `zstyle :prompt:pure:environment:nix-shell show no`
 
+Only Git is supported as a vcs by default. To activate more VCS systems you need to add them via `zstyle`:
+`zstyle ':prompt:pure:vcs_info' vcs_list git other-vcs`
+See `zstyle` `:vcs_info:* enable` for more info on the list.
+Extra options like showing arrows and dirty status are supported only for git. You'll need to define extra functions, see Custom VCS Support section below for details.
+
+## Custom VCS Support
+To support custom VCS systems, extra functions should be defined.
+They should be called `prompt_pure_async_${VCS}_${NAME}`, where `${VCS}` is the name of the VCS and `${NAME}` is the name of the function.
+They have to be defined before `pure` is loaded.
+
+See `git` commands in `pure.zsh` for examples.
+
+### `dirty`
+Arguments:
+- value of "${PURE_GIT_UNTRACKED_DIRTY}"
+
+Return code:
+- 0 if non-dirty
+- any other code if repo is dirty
+
+Output: None
+
+### `arrows`
+Arguments: None
+
+Return code:
+- 0 on success
+- any other code on failure
+
+Output:
+```
+<commits-ahead-of-remote>\t<commits-behind-of-remote>
+```
+
+Where `<commits-ahead-of-remote>` is the number of commits ahead of the remote branch, and `<commits-behind-of-remote>` is the number of commits behind the remote branch.
+They're separated by a tab character.
+
+### `fetch`
+Arguments:
+- `1` if `only_upstream` is set, `0` otherwise
+
+Return code:
+- `0` on success
+- `97` if no remote branch is available
+- `98`/`99` if fetch has failed
+- any other code on different failure
+
+Output: same as `arrows`
+
+Be careful not to lock up async worker by asking user for input, see `prompt_pure_async_git_fetch` for an example.
+Since output of `fetch` has to match `arrows`, it's recommended to call `arrows` at the end of `fetch`.
+
+### `stash`
+Arguments: None
+
+Return code:
+- 0 on success
+- any other code on failure
+
+Output:
+- `<number-of-stashes>` if there are stashes
+- empty string if there are no local stashes
+
 ## Colors
 
 As explained in ZSH's [manual](http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting), color values can be:


### PR DESCRIPTION
this is an example on how non-standard VCS systems can be supported in pure, with ability to provide different level of support by defining custom hooks.

I haven't implemented `_alias` hook though.