### PR TITLE
Add the ability to add the time to the preprompt line

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -11,7 +11,7 @@
 # %F => color dict
 # %f => reset color
 # %~ => current path
-# %* => time
+# %* => time (same as %D{%H:%M:%S}, see strftime(3))
 # %n => username
 # %m => shortname host
 # %(?..) => prompt conditional - %(condition.true.false)
@@ -130,6 +130,9 @@ prompt_pure_preprompt_render() {
 
 	# Initialize the preprompt array.
 	local -a preprompt_parts
+
+	# Optionally show the time.
+	[[ -n $PURE_PREPROMPT_STRFTIME ]] && preprompt_parts+=('%F{$prompt_pure_colors[time]}%D{'$PURE_PREPROMPT_STRFTIME'}')
 
 	# Suspended jobs in background.
 	if ((${(M)#jobstates:#suspended:*} != 0)); then
@@ -832,6 +835,7 @@ prompt_pure_setup() {
 		prompt:success       magenta
 		prompt:continuation  242
 		suspended_jobs       red
+		time                 white
 		user                 242
 		user:root            default
 		virtualenv           242

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,7 @@ prompt pure
 | **`PURE_GIT_DOWN_ARROW`**        | Defines the git down arrow symbol.                                                             | `⇣`            |
 | **`PURE_GIT_UP_ARROW`**          | Defines the git up arrow symbol.                                                               | `⇡`            |
 | **`PURE_GIT_STASH_SYMBOL`**      | Defines the git stash symbol.                                                                  | `≡`            |
+| **`PURE_PREPROMPT_STRFTIME`**    | Set to `%H:%M:%S` (see strftime(3)) to show the time in the preprompt line.                    | ``             |
 
 ## Zstyle options
 


### PR DESCRIPTION
Fixes #667. Happy to receive guidance on how to better follow your naming conventions.

My solution is superior to these:
- With the proposed workaround in #667,  you cannot re-source your `.zshrc` because it redefines the same function.
- With the [solution from the wiki](https://github.com/sindresorhus/pure/wiki/Customizations,-hacks-and-tweaks#show-system-time-in-prompt), the time appears before the arrow, not in the preprompt line.