### PR TITLE
Respect VIRTUAL_ENV_PROMPT variable

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -223,7 +223,11 @@ prompt_pure_precmd() {
 	# When VIRTUAL_ENV_DISABLE_PROMPT is empty, it was unset by the user and
 	# Pure should take back control.
 	if [[ -n $VIRTUAL_ENV ]] && [[ -z $VIRTUAL_ENV_DISABLE_PROMPT || $VIRTUAL_ENV_DISABLE_PROMPT = 12 ]]; then
-		psvar[12]="${VIRTUAL_ENV:t}"
+		if [[ -n $VIRTUAL_ENV_PROMPT ]]; then
+			psvar[12]="${VIRTUAL_ENV_PROMPT}"
+		else
+			psvar[12]="${VIRTUAL_ENV:t}"
+		fi
 		export VIRTUAL_ENV_DISABLE_PROMPT=12
 	fi
 


### PR DESCRIPTION
Whenever `VIRTUAL_ENV_PROMPT` is set, use it when injecting the venv name into the prompt.

Fixes #539.