### PR TITLE
Added option to skip initial newline on first prompt load

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -187,8 +187,14 @@ prompt_pure_preprompt_render() {
 	expanded_prompt="${(S%%)PROMPT}"
 
 	if [[ $1 == precmd ]]; then
-		# Initial newline, for spaciousness.
-		print
+		if [[ $PURE_SKIP_INITIAL_NEWLINE == 1 ]]; then
+			# If the PURE_SKIP_INITIAL_NEWLINE variable is equal to 1,
+			# skip the newline for the first time the prompt is loaded.
+			unset PURE_SKIP_INITIAL_NEWLINE
+		else 
+			# Initial newline, for spaciousness.
+			print
+		fi
 	elif [[ $prompt_pure_last_prompt != $expanded_prompt ]]; then
 		# Redraw the prompt.
 		prompt_pure_reset_prompt

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,7 @@ prompt pure
 | **`PURE_GIT_DOWN_ARROW`**        | Defines the git down arrow symbol.                                                             | `⇣`            |
 | **`PURE_GIT_UP_ARROW`**          | Defines the git up arrow symbol.                                                               | `⇡`            |
 | **`PURE_GIT_STASH_SYMBOL`**      | Defines the git stash symbol.                                                                  | `≡`            |
+| **`PURE_SKIP_INITIAL_NEWLINE`**  | Decides whether to skip printing a newline on initial prompt load.                             | `0`            |
 
 ## Zstyle options
 


### PR DESCRIPTION
New config variable: `PURE_SKIP_INITIAL_NEWLINE`

If set to `1`, this variable prevents the newline from being printed for the first time the prompt is loaded. This looks much cleaner in my opinion, so I thought I'd make it an option. It defaults to `0`, so it'll have no impact on users who don't explicitly set it.

<img width="788" height="122" alt="image" src="https://github.com/user-attachments/assets/bdfefe79-a1f6-480e-9cf5-5c929ab45150" />

Also updated the readme to include the new variable :)