### PR TITLE
add PURE_GIT_EXE for custom git command configuration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ prompt pure
 | Option                           | Description                                                                                    | Default value  |
 | :------------------------------- | :--------------------------------------------------------------------------------------------- | :------------- |
 | **`PURE_CMD_MAX_EXEC_TIME`**     | The max execution time of a process before its run time is shown when it exits.                | `5` seconds    |
+| **`PURE_GIT_EXE`**               | Custom Git command to use. Useful if you have Git wrappers or aliases you want to use.         | `command git`  |
 | **`PURE_GIT_PULL`**              | Prevents Pure from checking whether the current Git remote has been updated.                   | `1`            |
 | **`PURE_GIT_UNTRACKED_DIRTY`**   | Do not include untracked files in dirtiness check. Mostly useful on large repos (like WebKit). | `1`            |
 | **`PURE_GIT_DELAY_DIRTY_CHECK`** | Time in seconds to delay git dirty checking when `git status` takes > 5 seconds.               | `1800` seconds |


### PR DESCRIPTION
Allows users to specify alternative git commands or wrappers while maintaining backward compatibility.

Particularly useful for WSL2 where accessing Windows filesystem using WSL2 programs is incredibly slow, see https://github.com/microsoft/WSL/issues/4401.

Default remains `command git` for alias bypassing; set PURE_GIT_EXE to override (e.g., `export PURE_GIT_EXE='git'` for git alias, or `export PURE_GIT_EXE='hub'` for GitHub wrapper).