### PR TITLE
Use psvar for prompt construction

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -843,8 +843,8 @@ prompt_pure_setup() {
 	# dynamic via variables and psvar[12-20], updated each render
 	# in prompt_pure_preprompt_render. Numbering starts at 12 for
 	# legacy reasons (Pure originally used psvar[12] for virtualenv)
-	# and to avoid collisions with low psvar indices which users or
-	# prompt themes may rely on (e.g. %v expands psvar[1]).
+	# and to avoid collisions with low psvar indices which users
+	# may rely on (e.g. %v expands psvar[1]).
 	#
 	#   psvar[12] = suspended jobs symbol (e.g. ✦)
 	#   psvar[13] = username flag, renders user/host (e.g. user@host)


### PR DESCRIPTION
Previously, prompt_pure_preprompt_render rebuilt $PROMPT from scratch on
every call by conditionally assembling a preprompt_parts array,
stripping the old preprompt via $cleaned_ps1, and concatenating
everything back together. The $cleaned_ps1 hack relied on finding
$prompt_newline in $PROMPT to strip the preprompt and recover just the
bottom line.

$PROMPT is now constructed once in prompt_pure_setup using %(NV..) psvar
conditionals. The render function just updates psvar[1-9] values and
lets ZSH's native prompt expansion handle the rest.

This also fixes the duplicate preprompt lines seen with Ghostty after
their OSC 133 semantic prompt rewrite (ghostty-org/ghostty#10455).
Ghostty's shell integration injects continuation marks after every
newline in $PS1, turning $prompt_newline into a different sequence that
the $cleaned_ps1 pattern match can no longer find. This caused the
preprompt to accumulate on every render instead of being replaced.
The psvar approach is immune since $PROMPT is never parsed after setup.

Fixes #705

---

This refactor opens up a lot of new opportunities for pure. For instance, users can now modify or re-order the pre-prompt, if they so wish, without forking Pure. 😄
