### PR TITLE
Dim path separators

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -118,6 +118,16 @@ prompt_pure_set_colors() {
 	done
 }
 
+prompt_pure_format_path() {
+	setopt localoptions noshwordsplit
+
+	local current_path=${(%):-%~}
+	current_path=${current_path//\%/%%}
+
+	local path_separator="%F{$prompt_pure_colors[path:separator]}/%F{$prompt_pure_colors[path]}"
+	print -nr -- "%F{$prompt_pure_colors[path]}${current_path//\//$path_separator}%f"
+}
+
 prompt_pure_preprompt_render() {
 	setopt localoptions noshwordsplit
 
@@ -813,6 +823,7 @@ prompt_pure_setup() {
 		git:dirty            218
 		host                 242
 		path                 blue
+		path:separator       242
 		prompt:error         red
 		prompt:success       magenta
 		prompt:continuation  242
@@ -864,7 +875,7 @@ prompt_pure_setup() {
 	# Preprompt line: each %(NV..) section only renders when its psvar is non-empty.
 	PROMPT='%(12V.%F{$prompt_pure_colors[suspended_jobs]}%12v%f .)'
 	PROMPT+='%(13V.%F{$prompt_pure_colors['"${prompt_pure_state[user_color]:-user}"']}%n%f%F{$prompt_pure_colors[host]}@%m%f .)'
-	PROMPT+='%F{${prompt_pure_colors[path]}}%~%f'
+	PROMPT+='$(prompt_pure_format_path)'
 	PROMPT+='%(14V. %F{${prompt_pure_git_branch_color}}%14v%(15V.%F{$prompt_pure_colors[git:dirty]}%15v.)%f.)'
 	PROMPT+='%(16V. %F{$prompt_pure_colors[git:action]}%16v%f.)'
 	PROMPT+='%(17V. %F{$prompt_pure_colors[git:arrow]}%17v%f.)'

--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,7 @@ Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release
 - `git:dirty` (218) - The asterisk showing the branch is dirty.
 - `host` (242) - The hostname when on a remote machine.
 - `path` (blue) - The current path, for example, `PWD`.
+- `path:separator` (242) - The path separators in the current path.
 - `prompt:error` (red) - The `PURE_PROMPT_SYMBOL` when the previous command has *failed*.
 - `prompt:success` (magenta) - The `PURE_PROMPT_SYMBOL` when the previous command has *succeeded*.
 - `prompt:continuation` (242) - The color for showing the state of the parser in the continuation prompt (PS2). It's the pink part in [this screenshot](https://user-images.githubusercontent.com/147409/70068574-ebc74800-15f8-11ea-84c0-8b94a4b57ff4.png), it appears in the same spot as `virtualenv`. You could for example matching both colors so that Pure has a uniform look.


### PR DESCRIPTION
Fixes #432

IssueHunt bounty: https://issuehunt.io/repos/5890857/issues/432

## Changes
- Render the current path through a small formatter so `/` separators can use their own color.
- Add a `path:separator` color key, defaulting to `242`, matching the maintainer preference to dim separators instead of bolding them.
- Escape `%` in the expanded path before prompt rendering, covering the issue's noted buggy case.
- Document the new color key in the README.

## Test evidence
- `zsh -n pure.zsh`
- `zsh -n async.zsh`
- zsh rendering assertion covering default separators, a custom `zstyle :prompt:pure:path:separator color red`, and a current directory containing `%` (`a%b`)
- `git diff --check`