### PR TITLE
Dim path separators

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -118,6 +118,17 @@ prompt_pure_set_colors() {
 	done
 }
 
+prompt_pure_set_path() {
+	setopt localoptions noshwordsplit
+
+	local path=${(%):-%~}
+	path=${path//\%/%%}
+
+	local path_color=$prompt_pure_colors[path]
+	local separator="%F{${prompt_pure_colors[path:separator]}}/%F{$path_color}"
+	typeset -g prompt_pure_path="%F{$path_color}${path//\//$separator}%f"
+}
+
 prompt_pure_preprompt_render() {
 	setopt localoptions noshwordsplit
 
@@ -126,6 +137,7 @@ prompt_pure_preprompt_render() {
 	# Update git branch color based on cache state.
 	typeset -g prompt_pure_git_branch_color=$prompt_pure_colors[git:branch]
 	[[ -n ${prompt_pure_git_last_dirty_check_timestamp+x} ]] && prompt_pure_git_branch_color=$prompt_pure_colors[git:branch:cached]
+	prompt_pure_set_path
 
 	# Update psvar values. PROMPT uses %(NV.true.false) to conditionally
 	# render each part. See prompt_pure_setup for the PROMPT template.
@@ -813,6 +825,7 @@ prompt_pure_setup() {
 		git:dirty            218
 		host                 242
 		path                 blue
+		path:separator       242
 		prompt:error         red
 		prompt:success       magenta
 		prompt:continuation  242
@@ -839,6 +852,8 @@ prompt_pure_setup() {
 	# Initialize globals referenced by PROMPT via prompt subst.
 	typeset -gA prompt_pure_vcs_info
 	typeset -g prompt_pure_git_branch_color=$prompt_pure_colors[git:branch]
+	typeset -g prompt_pure_path
+	prompt_pure_set_path
 
 	# Construct PROMPT once, both preprompt and prompt line. Kept
 	# dynamic via variables and psvar[12-20], updated each render
@@ -864,7 +879,7 @@ prompt_pure_setup() {
 	# Preprompt line: each %(NV..) section only renders when its psvar is non-empty.
 	PROMPT='%(12V.%F{$prompt_pure_colors[suspended_jobs]}%12v%f .)'
 	PROMPT+='%(13V.%F{$prompt_pure_colors['"${prompt_pure_state[user_color]:-user}"']}%n%f%F{$prompt_pure_colors[host]}@%m%f .)'
-	PROMPT+='%F{${prompt_pure_colors[path]}}%~%f'
+	PROMPT+='${prompt_pure_path}'
 	PROMPT+='%(14V. %F{${prompt_pure_git_branch_color}}%14v%(15V.%F{$prompt_pure_colors[git:dirty]}%15v.)%f.)'
 	PROMPT+='%(16V. %F{$prompt_pure_colors[git:action]}%16v%f.)'
 	PROMPT+='%(17V. %F{$prompt_pure_colors[git:arrow]}%17v%f.)'

--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,7 @@ Colors can be changed by using [`zstyle`](http://zsh.sourceforge.net/Doc/Release
 - `git:dirty` (218) - The asterisk showing the branch is dirty.
 - `host` (242) - The hostname when on a remote machine.
 - `path` (blue) - The current path, for example, `PWD`.
+- `path:separator` (242) - The path separators in the current path.
 - `prompt:error` (red) - The `PURE_PROMPT_SYMBOL` when the previous command has *failed*.
 - `prompt:success` (magenta) - The `PURE_PROMPT_SYMBOL` when the previous command has *succeeded*.
 - `prompt:continuation` (242) - The color for showing the state of the parser in the continuation prompt (PS2). It's the pink part in [this screenshot](https://user-images.githubusercontent.com/147409/70068574-ebc74800-15f8-11ea-84c0-8b94a4b57ff4.png), it appears in the same spot as `virtualenv`. You could for example matching both colors so that Pure has a uniform look.


### PR DESCRIPTION
Fixes #432

IssueHunt bounty: https://issuehunt.io/r/sindresorhus/pure/issues/432

## Changes
- Render the current path through a prompt-safe path variable so path separators can use their own color.
- Add a `path:separator` color key, defaulting to `242`, while keeping `path` on the existing color.
- Escape `%` in the expanded path before prompt rendering so directories containing percent signs render correctly.
- Document the new color key in the README.

## Tested
- `zsh -n pure.zsh`
- `zsh -n async.zsh`
- zsh rendering assertions for default separators, custom separator color, and a path containing `%`
- `git diff --check`


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#432: Higlight slashes in the path to visualize the path components](https://oss.issuehunt.io/repos/5890857/issues/432)
---
</details>
<!-- /Issuehunt content-->