### PR TITLE
Dim path separators

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -118,6 +118,17 @@ prompt_pure_set_colors() {
 	done
 }
 
+prompt_pure_set_path() {
+	setopt localoptions noshwordsplit
+
+	local current_path separator
+	current_path=${(%):-%~}
+	current_path=${current_path//\%/%%}
+	separator=$'%{\e[2m%}/%{\e[22m%}'
+
+	typeset -g prompt_pure_path="%F{${prompt_pure_colors[path]}}${current_path//\//$separator}%f"
+}
+
 prompt_pure_preprompt_render() {
 	setopt localoptions noshwordsplit
 
@@ -154,6 +165,8 @@ prompt_pure_preprompt_render() {
 
 	# psvar[19]: Command execution time.
 	psvar[19]=${prompt_pure_cmd_exec_time}
+
+	prompt_pure_set_path
 
 	# Expand the prompt for future comparison.
 	local expanded_prompt
@@ -839,6 +852,8 @@ prompt_pure_setup() {
 	# Initialize globals referenced by PROMPT via prompt subst.
 	typeset -gA prompt_pure_vcs_info
 	typeset -g prompt_pure_git_branch_color=$prompt_pure_colors[git:branch]
+	typeset -g prompt_pure_path
+	prompt_pure_set_path
 
 	# Construct PROMPT once, both preprompt and prompt line. Kept
 	# dynamic via variables and psvar[12-20], updated each render
@@ -864,7 +879,7 @@ prompt_pure_setup() {
 	# Preprompt line: each %(NV..) section only renders when its psvar is non-empty.
 	PROMPT='%(12V.%F{$prompt_pure_colors[suspended_jobs]}%12v%f .)'
 	PROMPT+='%(13V.%F{$prompt_pure_colors['"${prompt_pure_state[user_color]:-user}"']}%n%f%F{$prompt_pure_colors[host]}@%m%f .)'
-	PROMPT+='%F{${prompt_pure_colors[path]}}%~%f'
+	PROMPT+='${prompt_pure_path}'
 	PROMPT+='%(14V. %F{${prompt_pure_git_branch_color}}%14v%(15V.%F{$prompt_pure_colors[git:dirty]}%15v.)%f.)'
 	PROMPT+='%(16V. %F{$prompt_pure_colors[git:action]}%16v%f.)'
 	PROMPT+='%(17V. %F{$prompt_pure_colors[git:arrow]}%17v%f.)'


### PR DESCRIPTION
Fixes #432.

This dims the `/` separators in the rendered path so the path components are easier to scan, while leaving the path text itself on the existing `path` color.

The expanded path is also `%`-escaped before prompt rendering, so directories containing `%` do not get interpreted as prompt escapes.

Tested with:
- `zsh -n pure.zsh`
- `zsh -n async.zsh`
- `zsh -f /tmp/pure-path-separator-test.zsh`


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#432: Higlight slashes in the path to visualize the path components](https://oss.issuehunt.io/repos/5890857/issues/432)
---
</details>
<!-- /Issuehunt content-->